### PR TITLE
fix(swagger): 改用 Pydantic Generic 修正 Swagger 缺少 type 的問題

### DIFF
--- a/src/router/res/response.py
+++ b/src/router/res/response.py
@@ -1,27 +1,32 @@
-from typing import Optional, Any, Dict
+from typing import Optional, Any, Dict, Generic, TypeVar
 
 from fastapi import status
 from fastapi.responses import JSONResponse
-from pydantic import create_model, BaseModel
+from pydantic import BaseModel
+
+T = TypeVar('T')
 
 
-# ref: https://github.com/tiangolo/fastapi/issues/3737
-def idempotent_response(route: str, model: Any) -> (Dict):
-    responses: Dict = {
+class ApiResponse(BaseModel, Generic[T]):
+    code: str = '0'
+    msg: str = 'ok'
+    data: Optional[T] = None
+
+
+def idempotent_response(route: str, model: Any) -> Dict:
+    return {
         200: {
-            'model': create_model(route, code=(str, ...), msg=(str, ...), data=(model, ...))
+            'model': ApiResponse[model]
         }
     }
-    return responses
 
 
-def post_response(route: str, model: Any) -> (Dict):
-    responses: Dict = {
+def post_response(route: str, model: Any) -> Dict:
+    return {
         201: {
-            'model': create_model(route, code=(str, ...), msg=(str, ...), data=(model, ...))
+            'model': ApiResponse[model]
         }
     }
-    return responses
 
 
 def post_success(data=None, msg='ok', code='0'):


### PR DESCRIPTION
## Summary

- `idempotent_response` / `post_response` 原本使用 `create_model` workaround（參見原本的 GitHub issue 連結），在 Pydantic v2 中無法讓 FastAPI 正確將 nested model schema 加入 OpenAPI `components/schemas`，導致 Swagger 的 `data` 欄位缺少 type 資訊
- 改用 Pydantic v2 原生的 `Generic[T]` 定義 `ApiResponse[T]`，所有 nested models（如 `MentorProfileVO`、`SearchMentorProfileListVO` 等深層 schema）現在會正確出現在 Swagger docs
- 只改動 `src/router/res/response.py`，所有 router 檔案不需要修改

## Test plan

- [ ] 部署後開啟 Swagger UI，確認各 API response 的 `data` 欄位有正確顯示 schema type
- [ ] 確認 `components/schemas` 區塊有包含 `MentorProfileVO`、`SearchMentorProfileVO`、`ReservationInfoListVO` 等 nested models
- [ ] 確認現有 API 行為不受影響（`res_success` / `post_success` 回傳邏輯未更動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Standardized API response format across all endpoints for improved consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->