### PR TITLE
feat(openapi): 補全所有 endpoint 的 response schema 並修正 VO 型別錯誤

### DIFF
--- a/src/domain/auth/model/auth_model.py
+++ b/src/domain/auth/model/auth_model.py
@@ -178,3 +178,18 @@ class SignupResponseVO(BaseModel):
 class LoginResponseVO(SignupResponseVO):
     # TODO: define user VO
     user: ProfileVO
+
+
+class EmailSentVO(BaseModel):
+    """Returned by signup, email resend, and password reset email endpoints."""
+    ttl_secs: int
+
+
+class TokenRefreshAuthVO(BaseModel):
+    user_id: int
+    token: str
+
+
+class TokenRefreshVO(BaseModel):
+    """Returned by POST /token (refresh token pair)."""
+    auth: TokenRefreshAuthVO

--- a/src/domain/auth/model/google_oauth_model.py
+++ b/src/domain/auth/model/google_oauth_model.py
@@ -1,10 +1,38 @@
 import logging
+from typing import Optional
 
 from pydantic import BaseModel, EmailStr
 
+from src.domain.user.model.user_model import ProfileVO
+
 log = logging.getLogger(__name__)
+
 
 class GoogleAuthorizeDTO(BaseModel):
     email: EmailStr
     # redirect_uri: Optional[str] = None  # 可選的前端重定向 URI
+
+
+class GoogleAuthorizeVO(BaseModel):
+    """Returned by /authorize/signup and /authorize/login."""
+    authorization_url: str
+    state: str
+
+
+class GoogleCallbackAuthVO(BaseModel):
+    email: Optional[str] = None
+    user_id: Optional[int] = None
+    token: Optional[str] = None
+    region: Optional[str] = None
+    created_at: Optional[int] = None
+    online: Optional[bool] = None
+
+
+class GoogleCallbackVO(BaseModel):
+    """Returned by /callback. auth_type is SIGNUP or LOGIN.
+    For LOGIN, user is populated. For SIGNUP, ttl_secs is populated."""
+    auth_type: str
+    auth: GoogleCallbackAuthVO
+    user: Optional[ProfileVO] = None
+    ttl_secs: Optional[int] = None
 

--- a/src/domain/user/model/reservation_model.py
+++ b/src/domain/user/model/reservation_model.py
@@ -50,8 +50,8 @@ class ReservationDTO(UpdateReservationDTO):
 
 class RUserInfoVO(BaseModel):
     user_id: Optional[int] = Field(None, example=0)
-    # role: Optional[str] = Field(None, example=RoleType.MENTEE.value,
-    #                      pattern=f'^({RoleType.MENTOR.value}|{RoleType.MENTEE.value})$')
+    role: Optional[str] = Field(None, example=RoleType.MENTEE.value,
+                         pattern=f'^({RoleType.MENTOR.value}|{RoleType.MENTEE.value})$')
     status: Optional[str] = Field(
         None,
         example=BookingStatus.PENDING.value,
@@ -60,7 +60,7 @@ class RUserInfoVO(BaseModel):
     name: Optional[str] = ''
     avatar: Optional[str] = ''
     job_title: Optional[str] = ''
-    years_of_experience: Optional[int] = 0
+    years_of_experience: Optional[str] = '0'
 
 
 class ReservationVO(ReservationDTO):
@@ -87,5 +87,5 @@ class ReservationInfoVO(BaseModel):
 
 
 class ReservationInfoListVO(BaseModel):
-    reservations: Optional[List[ReservationInfoVO]] = []
+    reservations: List[ReservationInfoVO] = []
     next_dtend: Optional[int] = 0

--- a/src/router/v1/auth.py
+++ b/src/router/v1/auth.py
@@ -20,7 +20,9 @@ router = APIRouter(
 )
 
 
-@router.post('/signup', status_code=201)
+@router.post('/signup',
+             responses=post_response('signup', EmailSentVO),
+             status_code=201)
 async def signup(
     body: SignupDTO = Body(...),
 ):
@@ -28,7 +30,9 @@ async def signup(
     return post_success(data=data, msg='email_sent')
 
 
-@router.post('/email/resend', status_code=201)
+@router.post('/email/resend',
+             responses=post_response('signup_email_resend', EmailSentVO),
+             status_code=201)
 async def signup_email_resend(
     email: EmailStr = Body(..., embed=True),
 ):
@@ -61,6 +65,7 @@ async def login(
 
 
 @router.post('/token',
+             responses=post_response('refresh_token', TokenRefreshVO),
              status_code=201)
 async def refresh_token(
     payload: NewTokenDTO = Depends(refresh_token_check),
@@ -69,7 +74,9 @@ async def refresh_token(
     return AuthService.auth_response(data=data)
 
 
-@router.post('/logout', status_code=201)
+@router.post('/logout',
+             responses=post_response('logout', None),
+             status_code=201)
 async def logout(
     user_id: int = Body(..., embed=True),
 ):
@@ -77,7 +84,8 @@ async def logout(
     return post_success(data=data, msg=msg)
 
 
-@router.put('/password/{user_id}/update')
+@router.put('/password/{user_id}/update',
+            responses=idempotent_response('update_password', None))
 async def update_password(
     user_id: int = Path(...),
     update_password_dto: UpdatePasswordDTO = Body(...),
@@ -87,7 +95,8 @@ async def update_password(
     return res_success(msg='update success')
 
 
-@router.get('/password/reset/email')
+@router.get('/password/reset/email',
+            responses=idempotent_response('send_reset_password_email', EmailSentVO))
 async def send_reset_password_comfirm_email(
     email: EmailStr,
 ):
@@ -95,7 +104,8 @@ async def send_reset_password_comfirm_email(
     return res_success(data=data, msg='send_email_success')
 
 
-@router.put('/password/reset')
+@router.put('/password/reset',
+            responses=idempotent_response('reset_password', None))
 async def reset_password(
     body: ResetPasswordBodyDTO = Body(...),
     verify_token: str = Query(...),

--- a/src/router/v1/google_oauth.py
+++ b/src/router/v1/google_oauth.py
@@ -6,6 +6,7 @@ from fastapi.responses import RedirectResponse
 from ..req.authorization import *
 from ..res.response import *
 from ...app._di.injection import _google_oauth_service
+from ...domain.auth.model.google_oauth_model import GoogleAuthorizeVO, GoogleCallbackVO
 
 log = logging.getLogger(__name__)
 
@@ -16,18 +17,25 @@ router = APIRouter(
     responses={404: {'description': 'Not found'}},
 )
 
-@router.post('/authorize/signup', status_code=201)
+@router.post('/authorize/signup',
+             responses=post_response('oauth_authorize_signup', GoogleAuthorizeVO),
+             status_code=201)
 async def oauth_authorize_signup():
     data = await _google_oauth_service.get_authorization_url_by_signup()
     return post_success(data=data, msg='Authorization URL generated successfully!')
 
-@router.post('/authorize/login', status_code=201)
+
+@router.post('/authorize/login',
+             responses=post_response('oauth_authorize_login', GoogleAuthorizeVO),
+             status_code=201)
 async def oauth_authorize_login():
     data = await _google_oauth_service.get_authorization_url_by_login()
     return post_success(data=data, msg='Authorization URL generated successfully!')
 
 
-@router.post('/callback', status_code=201)
+@router.post('/callback',
+             responses=post_response('oauth_callback', GoogleCallbackVO),
+             status_code=201)
 async def oauth_callback(
     code: str = Body(..., embed=True),
     state: str = Body(..., embed=True),

--- a/src/router/v1/oauth.py
+++ b/src/router/v1/oauth.py
@@ -19,7 +19,9 @@ router = APIRouter(
     responses={404: {'description': 'Not found'}},
 )
 
-@router.post('/signup/{auth_type}', status_code=201)
+@router.post('/signup/{auth_type}',
+             responses=post_response('signup_oauth', EmailSentVO),
+             status_code=201)
 async def signup_oauth(
     auth_type: OAuthType = Path(...),
     body: SignupOauthDTO = Body(...),


### PR DESCRIPTION
- 新增 EmailSentVO、TokenRefreshVO 供 auth endpoints 使用
- 新增 GoogleAuthorizeVO、GoogleCallbackVO 供 Google OAuth endpoints 使用
- 補上 11 個缺少 responses= 的 endpoints（auth、oauth、google_oauth）
- RUserInfoVO 新增 role 欄位、修正 years_of_experience 型別 int → str

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved API response documentation with explicit response schemas across authentication endpoints, including email confirmation, token refresh, and Google OAuth authorization flows

* **New Features**
  * Enhanced user profile data structure with role and experience information fields for better data clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->