### PR TITLE
fix(model): expose typed MetadataVO for profession_metadata and InterestVO.desc

### DIFF
--- a/src/domain/user/model/common_model.py
+++ b/src/domain/user/model/common_model.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from pydantic import BaseModel
 
@@ -8,13 +8,18 @@ from ....config.constant import *
 log = logging.getLogger(__name__)
 
 
+class MetadataVO(BaseModel):
+    desc: Optional[str] = None
+    icon: Optional[str] = None
+
+
 class InterestVO(BaseModel):
     id: int
     category: InterestCategory = None
     language: Optional[str] = None
     subject_group: str = 'unknown'
     subject: Optional[str] = ''
-    desc: Optional[Dict] = {}
+    desc: Optional[MetadataVO] = None
 
 
 class InterestListVO(BaseModel):
@@ -31,7 +36,7 @@ class ProfessionDTO(BaseModel):
 class ProfessionVO(ProfessionDTO):
     subject_group: str = 'unknown'
     subject: str = ''
-    profession_metadata: Dict = {}
+    profession_metadata: MetadataVO = MetadataVO()
     language: Optional[str] = ''
 
 


### PR DESCRIPTION
## Summary

- Adds `MetadataVO(desc: str, icon: str)` nested model to `common_model.py`
- Replaces `InterestVO.desc: Optional[Dict]` → `Optional[MetadataVO]`
- Replaces `ProfessionVO.profession_metadata: Dict` → `MetadataVO`
- Removes now-unused `Dict` import

## Why

Frontend OpenAPI codegen was generating `Record<string, never>` for these fields because they were typed as bare `dict`. With explicit Pydantic models, codegen will produce proper typed objects, removing the need for manual casts on the frontend.

Closes Xchange-Taiwan/X-Talent-Tracker#88

🤖 Generated with [Claude Code](https://claude.com/claude-code)