### PR TITLE
feat(auth): add OIDC id_token callback support and harden delete-acco…

### DIFF
--- a/src/app/_di/injection.py
+++ b/src/app/_di/injection.py
@@ -1,4 +1,5 @@
 from src.config.dynamodb import dynamodb
+from src.config.conf import STAGE
 from src.domain.auth.service.auth_service import AuthService
 from src.domain.auth.service.google_oauth_service import GoogleOAuthService
 from src.domain.auth.service.oauth_service import OAuthService
@@ -11,8 +12,8 @@ from src.infra.cache.local_cache_adapter import LocalCacheAdapter
 from src.infra.client.async_service_api_adapter import AsyncServiceApiAdapter
 
 service_client = AsyncServiceApiAdapter()
-gw_cache = DynamoDbCacheAdapter(dynamodb)
 local_cache = LocalCacheAdapter()
+gw_cache = local_cache if STAGE == 'local' else DynamoDbCacheAdapter(dynamodb)
 
 _auth_service: AuthService = AuthService(service_client, gw_cache)
 _oauth_service: OAuthService = OAuthService(service_client, gw_cache)

--- a/src/domain/auth/model/google_oauth_model.py
+++ b/src/domain/auth/model/google_oauth_model.py
@@ -35,4 +35,5 @@ class GoogleCallbackVO(BaseModel):
     auth: GoogleCallbackAuthVO
     user: Optional[ProfileVO] = None
     ttl_secs: Optional[int] = None
+    id_token: Optional[str] = None
 

--- a/src/domain/auth/service/auth_service.py
+++ b/src/domain/auth/service/auth_service.py
@@ -550,6 +550,11 @@ class AuthService:
         cached_data = await self.cache.get(str(user_id))
         if cached_data:
             account_type = cached_data.get('account_type')
+            cached_email = cached_data.get('email')
+            if not cached_email or cached_email != email:
+                raise UnauthorizedException(msg='Email does not match current session')
+        else:
+            raise UnauthorizedException(msg='Invalid session')
 
         if account_type is None:
             if body.password:
@@ -599,10 +604,32 @@ class AuthService:
 
     async def __verify_google_id_token(self, id_token: str, email: str):
         try:
-            auth_res = await self.req.simple_post(
-                f'{AUTH_SERVICE_URL}/v1/login',
-                json={'oauth_id': id_token, 'access_token': id_token})
-            if not auth_res or 'user_id' not in auth_res:
+            tokeninfo = await self.req.simple_get(
+                'https://oauth2.googleapis.com/tokeninfo',
+                params={'id_token': id_token},
+            )
+            if not tokeninfo:
+                raise UnauthorizedException(msg='Google identity verification failed')
+
+            token_email = tokeninfo.get('email')
+            if token_email != email:
+                raise UnauthorizedException(msg='Google identity verification failed')
+
+            # Google tokeninfo returns audience in `aud`.
+            aud = tokeninfo.get('aud')
+            if aud != GOOGLE_CLIENT_ID:
+                raise UnauthorizedException(msg='Google identity verification failed')
+
+            iss = tokeninfo.get('iss')
+            if iss not in {'accounts.google.com', 'https://accounts.google.com'}:
+                raise UnauthorizedException(msg='Google identity verification failed')
+
+            exp = tokeninfo.get('exp')
+            if not exp or int(exp) <= current_seconds():
+                raise UnauthorizedException(msg='Google identity verification failed')
+
+            # tokeninfo may return string values like "true"
+            if str(tokeninfo.get('email_verified', '')).lower() != 'true':
                 raise UnauthorizedException(msg='Google identity verification failed')
         except Exception as e:
             log.error(f'{self.cls_name}.__verify_google_id_token failed, email={email}, err={e}')

--- a/src/domain/auth/service/google_oauth_service.py
+++ b/src/domain/auth/service/google_oauth_service.py
@@ -52,7 +52,8 @@ class GoogleOAuthService(AuthService):
             'client_id': self.google_client_id,
             'redirect_uri': self.google_redirect_uri,
             'response_type': 'code',
-            'scope': 'email profile',
+            # Include openid so Google token endpoint returns OIDC id_token.
+            'scope': 'openid email profile',
             'state': state,
             'access_type': 'offline',
             'prompt': 'consent',
@@ -80,6 +81,7 @@ class GoogleOAuthService(AuthService):
         # 獲取用戶信息
         user_info = await self.__get_user_info(token_data['access_token'])
 
+        id_token = token_data.get('id_token')
         google_oauth_data = {
             'oauth_id': user_info['sub'],
             'email': user_info['email'],
@@ -90,11 +92,18 @@ class GoogleOAuthService(AuthService):
         # 檢查用戶是否已存在
         if state_data.get('auth_type') == AuthorizeType.SIGNUP.value:
             signup_body = SignupOauthDTO.model_validate(google_oauth_data)
-            return await self.signup_oauth_and_send_email(signup_body)
+            signup_res = await self.signup_oauth_and_send_email(signup_body)
+            if id_token:
+                signup_res['id_token'] = id_token
+            return signup_res
 
         if state_data.get('auth_type') == AuthorizeType.LOGIN.value:
             signin_body = LoginOauthDTO.model_validate(google_oauth_data)
-            return await self.login_oauth(signin_body, language=DEFAULT_LANGUAGE)
+            return await self.login_oauth(
+                signin_body,
+                language=DEFAULT_LANGUAGE,
+                id_token=id_token,
+            )
 
         raise ServerException(msg='Invalid authorization type provided')
 
@@ -187,7 +196,12 @@ class GoogleOAuthService(AuthService):
         return data
 
 
-    async def login_oauth(self, body: LoginOauthDTO, language: str = DEFAULT_LANGUAGE):
+    async def login_oauth(
+        self,
+        body: LoginOauthDTO,
+        language: str = DEFAULT_LANGUAGE,
+        id_token: Optional[str] = None,
+    ):
         tokeninfo = await self.__get_tokeninfo(body.access_token)
         oauth_id = str(tokeninfo.get("sub", None))
         if oauth_id != body.oauth_id:
@@ -206,11 +220,14 @@ class GoogleOAuthService(AuthService):
         auth_res = self.apply_token(auth_res)
         user_res = await self.get_user_profile(user_id, language)
         auth_res = self.filter_auth_res(auth_res)
-        return {
+        res = {
             "auth_type": AuthorizeType.LOGIN.value,
             "auth": auth_res,
             "user": user_res,
         }
+        if id_token:
+            res["id_token"] = id_token
+        return res
 
 
     async def __req_login(self, body: LoginOauthDTO, email: EmailStr, language: str):


### PR DESCRIPTION
…unt verification

Return Google id_token from OAuth callback/login flow, validate Google delete-account reauth via tokeninfo checks, enforce session email matching for deletion, and use local cache in local stage to avoid DynamoDB permission failures.

Made-with: Cursor