### PR TITLE
fix(auth): fix Google account delete always returning 401

### DIFF
--- a/src/domain/auth/service/auth_service.py
+++ b/src/domain/auth/service/auth_service.py
@@ -676,7 +676,7 @@ class AuthService:
 
     async def __verify_google_id_token(self, id_token: str, email: str):
         try:
-            tokeninfo = await self.req.simple_get(
+            tokeninfo = await self.req.get_req(
                 'https://oauth2.googleapis.com/tokeninfo',
                 params={'id_token': id_token},
             )


### PR DESCRIPTION
## Summary
- `__verify_google_id_token` was calling `self.req.simple_get()` to fetch Google's tokeninfo API
- `simple_get` is designed for internal BFF services that return `{code, msg, data}` envelope — it returns `response.data`, which is `{}` for Google's flat JSON response
- `not {}` is `True` in Python, so `UnauthorizedException` was always raised before any validation could happen

## Root Cause
```python
# Before (broken): simple_get returns parsed_data.get('data', {}) = {}
tokeninfo = await self.req.simple_get('https://oauth2.googleapis.com/tokeninfo', ...)
if not tokeninfo:  # not {} == True → always raises 401
    raise UnauthorizedException(...)

# After (fixed): get_req returns raw JSON from Google
tokeninfo = await self.req.get_req('https://oauth2.googleapis.com/tokeninfo', ...)
```

## Test plan
- [ ] Log in with a Google account
- [ ] Navigate to account deletion page
- [ ] Confirm Google re-authentication flow completes without 401
- [ ] Confirm account is deleted successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)