### PR TITLE
fix(auth): use Google profile as onboarding fallback on Google login

### DIFF
--- a/src/domain/auth/service/google_oauth_service.py
+++ b/src/domain/auth/service/google_oauth_service.py
@@ -101,10 +101,14 @@ class GoogleOAuthService(AuthService):
 
         if state_data.get('auth_type') == AuthorizeType.LOGIN.value:
             signin_body = LoginOauthDTO.model_validate(google_oauth_data)
+            # 帶上 Google 帳號的 name/picture，作為 onboarding 預設值的來源；
+            # login_oauth 只會在 DB profile 還沒填的欄位上回填，使用者已自訂的不會被覆蓋。
             return await self.login_oauth(
                 signin_body,
                 language=DEFAULT_LANGUAGE,
                 id_token=id_token,
+                default_name=user_info.get('name'),
+                default_avatar=user_info.get('picture'),
             )
 
         raise ServerException(msg='Invalid authorization type provided')
@@ -203,6 +207,8 @@ class GoogleOAuthService(AuthService):
         body: LoginOauthDTO,
         language: str = DEFAULT_LANGUAGE,
         id_token: Optional[str] = None,
+        default_name: Optional[str] = None,
+        default_avatar: Optional[str] = None,
     ):
         tokeninfo = await self.__get_tokeninfo(body.access_token)
         oauth_id = str(tokeninfo.get("sub", None))
@@ -227,6 +233,12 @@ class GoogleOAuthService(AuthService):
         )
         auth_res = self.apply_token(auth_res)
         user_res = await self.get_user_profile(user_id, language)
+        # 首次登入(尚未 onboarding)時，DB profile 的 name/avatar 會是空字串。
+        # 用 Google 帳號的 name/picture 作為 onboarding 預設值回填——
+        # 一旦使用者自訂過 profile，DB 即為唯一真實來源，這裡不會覆蓋。
+        user_res = self.__apply_google_profile_defaults(
+            user_res, default_name, default_avatar
+        )
         auth_res = self.filter_auth_res(auth_res)
         if cookie_refresh:
             auth_res[REFRESH_TOKEN_KEY] = cookie_refresh
@@ -238,6 +250,20 @@ class GoogleOAuthService(AuthService):
         if id_token:
             res["id_token"] = id_token
         return res
+
+    @staticmethod
+    def __apply_google_profile_defaults(
+        user_res: Any,
+        default_name: Optional[str],
+        default_avatar: Optional[str],
+    ):
+        if not isinstance(user_res, dict):
+            return user_res
+        if default_name and not user_res.get("name"):
+            user_res["name"] = default_name
+        if default_avatar and not user_res.get("avatar"):
+            user_res["avatar"] = default_avatar
+        return user_res
 
 
     async def __req_login(self, body: LoginOauthDTO, email: EmailStr, language: str):


### PR DESCRIPTION
## Summary
- Google OAuth 第一次登入後到 onboarding page 顯示空白姓名、無頭像。
- Root cause:`login_oauth` 直接把 user service 拿到的 DB profile 透傳給前端,但首次登入時 DB profile 的 `name`/`avatar` 還是空字串,onboarding form 因此沒預設值。
- Fix:`handle_callback` LOGIN 分支把已經拿到的 Google `/userinfo` `name`/`picture` 傳進 `login_oauth`,只在 DB profile 該欄位為空時當作 onboarding 預設值回填,**不寫進 DB**。

## 設計重點
- **DB 為唯一真實來源**:這個 PR 不新增任何 DB 寫入,Google 值只是在 BFF 回應上做 fallback merge。
- **使用者自訂優先**:`__apply_google_profile_defaults` 只在 `not user_res.get('name')` / `not user_res.get('avatar')` 時填入,使用者上傳過頭像或改過名字後永遠不會被 Google 覆蓋。
- **Google 頭像更新自動跟上**:因為不快取 / 不寫 DB,只要使用者沒自訂,下次登入會拿到 Google 最新的 picture URL,不會卡在註冊當下的舊版。
- **零額外 HTTP**:`handle_callback` line 82 的 `__get_user_info` 本來就會呼叫,只是把已有的欄位多傳一層。
- **行為矩陣**

  | 情境 | DB profile | LOGIN response 的 user.name / avatar |
  |---|---|---|
  | 首次登入(onboarding 未完成) | name="" / avatar="" | Google 顯示名 / Google picture |
  | 已自訂名字、沒設頭像 | name="老王" / avatar="" | name="老王" / Google picture |
  | 完整自訂 | name="老王" / avatar="s3://..." | name="老王" / avatar="s3://..." |
  | Google 換頭像但 DB 已自訂 | name="老王" / avatar="s3://..." | 不被 Google 覆蓋 |
  | Google 換頭像但 DB 還空 | name="" / avatar="" | 拿到 Google 最新版 |

## 改動範圍
- `src/domain/auth/service/google_oauth_service.py`
  - `handle_callback` LOGIN 分支:把 `user_info.get('name')` / `user_info.get('picture')` 傳給 `login_oauth`。
  - `login_oauth`:新增 optional `default_name` / `default_avatar` 參數;`get_user_profile` 後呼叫新加的 `__apply_google_profile_defaults` 做 fallback merge。
  - `__apply_google_profile_defaults`(新增 static helper):只在欄位空字串/None 時回填,有值不動。
- 沒有改 `auth_service.py`、沒有改 SIGNUP 流程、沒有改 user service 的呼叫。

## Test plan
- [ ] 用全新 Google 帳號登入,onboarding 頁面顯示 Google 顯示名與頭像。
- [ ] 在 onboarding 改名字、上傳自訂頭像並送出,登出後重新登入,response 的 `data.user` 仍為自訂值,沒被 Google 蓋掉。
- [ ] 既有 email 登入流程不受影響(`login_oauth` 只在 Google OAuth 路徑上呼叫)。
- [ ] BFF Lambda log 確認 `__apply_google_profile_defaults` 不會寫 user service。

🤖 Generated with [Claude Code](https://claude.com/claude-code)