### PR TITLE
fix(client): set explicit httpx timeout to survive downstream cold start

### DIFF
--- a/src/infra/client/async_service_api_adapter.py
+++ b/src/infra/client/async_service_api_adapter.py
@@ -15,6 +15,11 @@ log = logging.getLogger(__name__)
 
 SUCCESS_CODE = "0"
 
+# Total response budget set well below the API Gateway 29s ceiling so a cold
+# downstream Lambda (Auth/User/Search) has time to finish its DB pool setup
+# instead of being cut off at httpx's 5s default and surfacing as a 500.
+_DEFAULT_TIMEOUT = httpx.Timeout(20.0, connect=5.0)
+
 
 def check_response_code(method: str, expected_code: int = 200):
     def decorator_check_response_code(func):
@@ -77,7 +82,7 @@ class AsyncServiceApiAdapter(IServiceApi):
         result = None
         response = None
         try:
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT) as client:
                 response = await client.get(url, params=params, headers=headers)
                 result = ServiceApiResponse.parse(response)
 
@@ -93,7 +98,7 @@ class AsyncServiceApiAdapter(IServiceApi):
     # NOTE: retrun native response
     async def get_req(self, url: str, params: Dict = None, headers: Dict = None) -> Any:
         try:
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT) as client:
                 response = await client.get(url, params=params, headers=headers)
                 response.raise_for_status()
                 return response.json()
@@ -118,7 +123,7 @@ class AsyncServiceApiAdapter(IServiceApi):
         result = None
         response = None
         try:
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT) as client:
                 response = await client.post(url, json=json, headers=headers)
                 result = ServiceApiResponse.parse(response)
 
@@ -134,7 +139,7 @@ class AsyncServiceApiAdapter(IServiceApi):
     # NOTE: retrun native response
     async def post_req(self, url: str, json: Dict, headers: Dict = None) -> Any:
         try:
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT) as client:
                 response = await client.post(url, json=json, headers=headers)
                 response.raise_for_status()
                 return response.json()
@@ -160,7 +165,7 @@ class AsyncServiceApiAdapter(IServiceApi):
         result = None
         response = None
         try:
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT) as client:
                 response = await client.put(url, json=json, headers=headers)
                 result = ServiceApiResponse.parse(response)
 
@@ -187,7 +192,7 @@ class AsyncServiceApiAdapter(IServiceApi):
         result = None
         response = None
         try:
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT) as client:
                 # httpx 0.27+：delete() 不支援 json=，需用 request("DELETE", ...)
                 response = await client.request(
                     'DELETE',


### PR DESCRIPTION
## Summary
- Every `httpx.AsyncClient()` in `async_service_api_adapter.py` was created without a `timeout=`, which means it inherits httpx's **5 second** default. That is shorter than the cold-start window of the downstream Auth / User / Search Lambdas (DB pool init alone is 3–5s on a cold container), so the first login after an idle period times out at the BFF and surfaces as a **500** even though the downstream is still warming up.
- This PR sets `timeout=httpx.Timeout(20.0, connect=5.0)` on all 6 `AsyncClient(...)` call sites via a single module-level constant. 20s read budget stays well under the API Gateway 29s ceiling and the Lambda 30s timeout, while giving downstream Lambdas enough room to finish a cold start.

## Why these numbers
| Hop | Limit | Notes |
|---|---|---|
| Auth cold start | ~3–7s typical, up to ~10s worst case | DB pool + DynamoDB + SES + imports |
| New httpx read | **20s** | comfortable margin over cold start |
| API Gateway | 29s | AWS-managed, hard ceiling |
| Lambda timeout | 30s | from \`serverless.yml\` |
| httpx connect | **5s** | TCP/TLS handshake — internal AWS network is fast, 5s already generous |

## Pairing
This fix pairs with \`fix/lazy-resource-init-cold-start\` on \`X-Career-Auth\`, which makes Auth's startup non-blocking. Either fix alone helps; together they should eliminate the cold-start 500.

## Test plan
- [ ] \`pytest test/\` passes locally
- [ ] Deploy to dev (\`./deploy.sh -e dev -r ap-northeast-1\`)
- [ ] After idle window (>15 min), hit \`POST /v1/auth/login\` and confirm 200/2xx instead of 500
- [ ] Repeat 3–5 times to confirm subsequent (warm) requests are fast
- [ ] Watch CloudWatch for any new \`ReadTimeout\` or \`ConnectTimeout\` exceptions
- [ ] Spot-check signup, OAuth callback, and a few User-service-backed endpoints to make sure no caller now hangs longer than expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)