### PR TITLE
feat(profile): pass through avatar_updated_at on profile VO/DTO

### DIFF
--- a/src/domain/user/model/user_model.py
+++ b/src/domain/user/model/user_model.py
@@ -13,6 +13,9 @@ class ProfileVO(BaseModel):
     user_id: int
     name: Optional[str] = ''
     avatar: Optional[str] = ''
+    # Unix epoch seconds; bumped only when the avatar URL actually changes.
+    # Frontend uses this as a cache buster for the stable S3 avatar URL.
+    avatar_updated_at: Optional[int] = None
     job_title: Optional[str] = ''
     company: Optional[str] = ''
     years_of_experience: Optional[str] = '0'
@@ -30,6 +33,7 @@ class ProfileDTO(BaseModel):
     user_id: Optional[int]
     name: Optional[str] = ''
     avatar: Optional[str] = ''
+    avatar_updated_at: Optional[int] = None
     job_title: Optional[str] = ''
     company: Optional[str] = ''
     years_of_experience: Optional[str] = '0'


### PR DESCRIPTION
## What Does This PR Do?

- Add `avatar_updated_at: Optional[int]` to BFF's `ProfileVO` and `ProfileDTO` (mirrors the new field added to X-Career-User). This makes the field appear in the OpenAPI schema for `MentorProfileVO`, so frontend `openapi-typescript` regeneration picks it up.
- The mentor profile route already returns the upstream dict via `jsonable_encoder`, so the value flows through without service-layer changes. No caching exists on this endpoint, so no cache invalidation needed.

## Demo

`GET /v1/mentors/{user_id}/{lang}/profile` — response now includes `avatar_updated_at` once X-Career-User is deployed.

## Screenshot

N/A

## Anything to Note?

- Pairs with the X-Career-User PR that adds the column + bump-on-change logic. Deploy X-Career-User first, then this BFF change, then run `pnpm generate:types` on the frontend.
- See the X-Career-User PR description for the full rationale.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
