### PR TITLE
feat(reservation): pass through avatar_updated_at on RUserInfoVO

### DIFF
--- a/src/domain/user/model/reservation_model.py
+++ b/src/domain/user/model/reservation_model.py
@@ -74,6 +74,7 @@ class RUserInfoVO(BaseModel):
     )
     name: Optional[str] = ''
     avatar: Optional[str] = ''
+    avatar_updated_at: Optional[int] = None
     job_title: Optional[str] = ''
     years_of_experience: Optional[str] = '0'
 


### PR DESCRIPTION
## Summary

- Mirror the new field added in X-Career-User (Xchange-Taiwan/X-Career-User#78) so the BFF OpenAPI spec exposes `avatar_updated_at` on every reservation `sender` / `participant`.
- Frontend uses this as a cache buster on the stable S3 avatar URL to avoid showing stale avatars on reservation cards (`/reservation/mentor`, `/reservation/mentee`, `AcceptReservationDialog`, `ReservationConversationDialog`).

Pure schema pass-through — the BFF reservation list endpoint already proxies the User service response without enrichment.

Closes Xchange-Taiwan/X-Talent-Tracker#243 (BFF-side scope)

## Test plan

- [ ] After deploying both services, hit `/reservations` via BFF and confirm the OpenAPI spec / response contains `participant.avatar_updated_at`
- [ ] Frontend `pnpm generate:types` picks up the new field
- [ ] No regression on existing reservation list / new-booking / accept-reject flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)