### PR TITLE
fix(storage): proxy avatar touch endpoint to User service

### DIFF
--- a/src/domain/user/model/user_model.py
+++ b/src/domain/user/model/user_model.py
@@ -6,7 +6,11 @@ from pydantic import BaseModel, Field
 from .common_model import ProfessionVO, InterestListVO
 from ....config.conf import DEFAULT_LANGUAGE
 
-log = logging.getLogger(__name__) 
+log = logging.getLogger(__name__)
+
+
+class AvatarTouchVO(BaseModel):
+    avatar_updated_at: int
 
 
 class ProfileVO(BaseModel):

--- a/src/domain/user/service/user_service.py
+++ b/src/domain/user/service/user_service.py
@@ -37,6 +37,20 @@ class UserService:
         res: Optional[Dict[str, Any]] = await self.service_api.simple_put(url=req_url, json=data.model_dump())
         return res
 
+    async def touch_avatar(self, user_id: int) -> Optional[Dict[str, Any]]:
+        """Bump the user's ``avatar_updated_at`` after a successful upload.
+
+        Per-user S3 avatar keys are stable, so re-uploads don't change
+        ``profile.avatar`` and the standard upsert path can't tell the bytes
+        have changed. The storage router calls this from the upload-completion
+        flow to refresh the cache buster.
+        """
+        req_url = f"{USER_SERVICE_URL}/v1/{USERS}/{user_id}/avatar/touch"
+        res: Optional[Dict[str, Any]] = await self.service_api.simple_post(
+            url=req_url, json={}
+        )
+        return res
+
     async def get_interests(self, language: Language, interest: InterestCategory) -> Dict:
         try:
             cache_key = self.cache_key(f"interests:{interest.value}", language.value)

--- a/src/router/v1/object_storage.py
+++ b/src/router/v1/object_storage.py
@@ -4,10 +4,11 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.params import Depends
 
 from ..req.authorization import verify_jwt_access, verify_path_user_id, verify_query_user_id
-from src.app._di.injection import _file_service
+from src.app._di.injection import _file_service, _user_service
 from src.config.conf import S3_REGION
 from src.config.exception import ForbiddenException
 from src.domain.file.model.file_info_model import FileInfoListVO
+from src.domain.user.model.user_model import AvatarTouchVO
 from src.infra.storage.global_object_storage import GlobalObjectStorage
 from src.router.res.response import idempotent_response, res_success, post_success
 
@@ -84,6 +85,24 @@ async def get_bucket_size(user_id: int):
 async def get_presigned_url_for_avatar(user_id: int):
     if user_id <= 0:
         raise HTTPException(status_code=400, detail="Invalid user_id. Must be a positive integer.")
-    
+
     res = _obj_store.get_presigned_url_for_avatar(user_id)
+    return res_success(data=res)
+
+
+@router.post('/avatar/touch/{user_id}',
+             dependencies=[Depends(verify_path_user_id)],
+             responses=idempotent_response('touch_avatar', AvatarTouchVO))
+async def touch_avatar(user_id: int):
+    """Bump avatar_updated_at after a successful S3 upload.
+
+    The presigned-URL flow (and the server-side upload flow) re-uses a stable
+    per-user S3 key, so profile.avatar's URL doesn't change on re-upload. The
+    frontend calls this once the S3 PUT/POST completes so the User service
+    can refresh the cache buster the standard profile upsert can't detect.
+    """
+    if user_id <= 0:
+        raise HTTPException(status_code=400, detail="Invalid user_id. Must be a positive integer.")
+
+    res = await _user_service.touch_avatar(user_id)
     return res_success(data=res)


### PR DESCRIPTION
## 這個 PR 在解什麼問題？

使用者換頭像之後，**其他人在 mentor-pool / reservation 卡片看到的還是舊頭像**，要等 30 天瀏覽器快取過期才會更新。

### 為什麼會這樣？

我們的 S3 頭像網址是固定的（每個 user 只有一個 `https://.../files/{user_id}/avatar`）。換頭像就是直接覆蓋同一個檔案、網址不變。瀏覽器 / Next.js Image Optimizer 看到網址沒變，就繼續用快取裡的舊圖。

我們本來有一個 `avatar_updated_at` 時間戳當作「換頭像版本號」，前端會把它附在網址後面 `?v=12345` 來破壞快取。但這個欄位的更新邏輯有 bug：

- User service 是「比對新舊網址，發現變了才更新時間戳」
- 但網址永遠是同一個（S3 key 固定）
- → 時間戳永遠不會被更新 → 沒有破壞快取的版本號 → 永遠看到舊圖

### 這個 PR 怎麼解？

加一個**獨立的 endpoint，前端上傳完頭像後直接呼叫它「告訴後端：頭像剛換過了」**，後端就更新時間戳。不用再靠網址比對去猜。

## 這支 BFF 做了什麼？

純粹**傳話**：

```
前端                     BFF（這個 PR）                 User service
 │                          │                               │
 │  POST /v1/storage/       │                               │
 │  avatar/touch/{userId}   │                               │
 ├─────────────────────────>│                               │
 │                          │  POST /v1/users/{userId}/     │
 │                          │  avatar/touch                 │
 │                          ├──────────────────────────────>│
 │                          │                               │ ← 這裡才真的更新 DB
 │                          │                               │   UPDATE profiles
 │                          │                               │   SET avatar_updated_at
 │                          │                               │     = current_seconds()
 │                          │                               │
 │                          │  { avatar_updated_at: 1745... }
 │                          │<──────────────────────────────┤
 │  { avatar_updated_at: 1745... }
 │<─────────────────────────┤
```

**BFF 自己不碰 DB、不存任何東西**。它只負責：
1. 收 FE 的 request
2. 轉發給 User service
3. 把 User service 的回傳結果原樣傳回 FE

新值來自 User service 那條 SQL 寫進 DB 的同一筆資料（`UPDATE ... RETURNING` 是 atomic 的，寫跟讀同一個 transaction，不會 race）。

## 這個 PR 改了什麼

- **`object_storage.py`** — 新增 route `POST /v1/storage/avatar/touch/{user_id}`，掛在現有 `/storage` 下面。權限驗證沿用現有的 `verify_path_user_id`（防止有人改別人的頭像時間戳）。
- **`user_service.py`** — 新增一個 method 把 request 轉發給 User service。
- **`user_model.py`** — 加一個小 `AvatarTouchVO` 給 OpenAPI 文件用。

## 配套 PR

這條鏈要一起部署：

| 順序 | Repo | PR | 角色 |
|---|---|---|---|
| 1 | X-Career-User | #79 | 真正在 DB update 時間戳的地方 |
| 2 | **X-Career-BFF**（本 PR） | #112 | 中間轉發 |
| 3 | X-Talent-Frontend | #564 | 上傳完頭像後呼叫這支 endpoint |

## Test plan

- [ ] 跟 User service touch endpoint 一起部署到 dev
- [ ] FE 換頭像，DevTools Network 看到 `POST /v1/storage/avatar/touch/{user_id}` 回 200，body 帶 `{ avatar_updated_at: <整數> }`
- [ ] 試著用別人的 user_id 打這支 — 應該被 `verify_path_user_id` 擋下
- [ ] 原本的 avatar 上傳 / presigned URL endpoint 沒影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)
