### PR TITLE
fix(auth): correct refresh token validity check and lifetime

### DIFF
--- a/src/router/req/authorization.py
+++ b/src/router/req/authorization.py
@@ -6,7 +6,7 @@ import jwt as jwt_util
 from fastapi import Depends, Path, Query, Request
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
-from ...config.conf import JWT_ALGORITHM, ACCESS_TOKEN_TTL, SHORT_TERM_TTL
+from ...config.conf import JWT_ALGORITHM, ACCESS_TOKEN_TTL, REFRESH_TOKEN_TTL
 from ...config.exception import *
 from ...infra.util.time_util import *
 
@@ -52,16 +52,16 @@ def expiration_time():
 
 def gen_refresh_token():
     prefix = str(uuid.uuid4()).replace('-', '')
-    expiration = expiration_time()
+    # 編碼於 token 尾端的過期時間需對齊 cookie max_age (REFRESH_TOKEN_TTL)，
+    # 而非 access token 的有效期 (ACCESS_TOKEN_TTL)。
+    expiration = current_seconds() + REFRESH_TOKEN_TTL
     return f'{prefix[0:20]}{expiration}'
 
 def valid_refresh_token(refresh_token: str) -> (bool):
     future_time_in_secs = int(refresh_token[-10:])
     current_time_in_secs = current_seconds()
-    diff = abs(future_time_in_secs - current_time_in_secs)
-    # 兩者誤差在過期時間的一半內，視為有效
-    passed = diff < SHORT_TERM_TTL / 2
-    log.info('\n\n\nfuture_t: %s, current_t: %s, diff: %s, passed: %s', future_time_in_secs, current_time_in_secs, diff, passed)
+    passed = current_time_in_secs < future_time_in_secs
+    log.info('future_t: %s, current_t: %s, passed: %s', future_time_in_secs, current_time_in_secs, passed)
     return passed
 
 


### PR DESCRIPTION
## 摘要

`POST /v1/auth/token` 在第一次 refresh 就會回 `401 invalid_grant`，前端測試呼叫 refresh API 全部失敗。根本原因在 `src/router/req/authorization.py`：

- `gen_refresh_token()` 將 `now + ACCESS_TOKEN_TTL`（預設 **30 分鐘**）編碼到 token 尾端，但 Set-Cookie 的 `max_age` 使用的是 `REFRESH_TOKEN_TTL`（預設 **30 天**）—— 兩者壽命不一致。
- `valid_refresh_token()` 使用 `passed = abs(exp - now) < SHORT_TERM_TTL / 2`，意思是「目前時間必須在編碼 exp 的 **±900 秒** 內才算有效」。剛發出的 token 其 `diff = 1800`、門檻 `900`，立刻被判定為無效。整體行為跟預期完全相反：token 只會在「快到期前後一小段視窗」才被接受。

### 具體範例

假設使用者在 unix 時間 `t0 = 1761800000` 登入，預設值 `ACCESS_TOKEN_TTL = 1800`、`SHORT_TERM_TTL = 1800`：

- `gen_refresh_token()` → 編碼進 token 的 exp = `t0 + 1800 = 1761801800`（token 最後 10 字元）。
- `valid_refresh_token()` 的判定條件：`abs(1761801800 - now) < 900` 才視為有效。

| 呼叫 refresh 的時機 | `now` | `diff = abs(exp − now)` | `diff < 900`？ | 結果 |
|---|---|---|---|---|
| 登入後 1 秒（前端常見情境） | t0 + 1s     | 1799 | ❌ | **401 invalid_grant** |
| 登入後 8 分鐘 | t0 + 500s    | 1300 | ❌ | **401 invalid_grant** |
| 登入後 17 分鐘 | t0 + 1000s  | 800  | ✅ | 201 OK |
| 剛好到編碼的 exp 時點 | t0 + 1800s | 0    | ✅ | 201 OK |
| 過 exp 後 15 分鐘 | t0 + 2700s   | 900  | ❌ | 401 invalid_grant |
| 過 exp 後 15 分 1 秒 | t0 + 2701s | 901  | ❌ | 401 invalid_grant |

換言之，這顆 token：

- **前 15 分鐘** 一律被拒（前端登入後立刻打 refresh 就是踩在這裡，所以測試永遠 401）。
- 只有在 **編碼 exp 前後 ±15 分鐘共 30 分鐘的視窗** 內才被接受。
- 過 exp 超過 15 分鐘後就再也用不了。

修正後：編碼 exp 改為 `t0 + REFRESH_TOKEN_TTL = t0 + 2,592,000 秒`（30 天），判定條件改為 `now < exp`，整顆 token 在 30 天內都有效，與 Set-Cookie 的 `max_age` 對齊。

### 修正內容

- `gen_refresh_token`：編碼 `now + REFRESH_TOKEN_TTL`，讓 token 內的 exp 與 cookie max-age 一致。
- `valid_refresh_token`：將絕對誤差判定改為 `current < future`，token 在實際過期前都有效。
- 移除已不再使用的 `SHORT_TERM_TTL` import。

對應 ticket：[Xchange-Taiwan/X-Talent-Tracker#95](https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/95)

## 測試計畫

- [ ] 登入 → 確認 response 帶 `refresh_token` HttpOnly cookie，JWT access token 可正常呼叫 API。
- [ ] 登入後立刻打 `POST /v1/auth/token`（`grant_type=refresh_token` + 新 refresh token）→ 預期 `201`，並回新的 refresh cookie 與新 JWT（修正前：`401 invalid_grant`）。
- [ ] 使用已被輪替（撤銷）的舊 refresh token 再打一次 → 預期 `401 invalid_grant`。
- [ ] 前端整合：NextAuth refresh callback（`auth.config.ts`）能成功換到新 JWT，不會把使用者踢回登入頁。

## 後續追蹤（不含於本 PR）

- Cookie 屬性 `samesite=Strict; secure=True` 在跨網域 / 本機 HTTP 情境會擋掉 refresh cookie，待前後端部署拓樸確定後再調整。
- 前端在 `refreshToken.ts` 從 `fetch` response headers 讀取 `Set-Cookie`，但瀏覽器不會把這個 header 暴露給 JS；第一次 refresh 後輪替的新 refresh token 前端拿不到。後續需擇一處理：將新 refresh token 一併放回 JSON body，或全面改成 cookie-only 流程搭配 `credentials: include`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)