### PR TITLE
chore(profile): remove avatar_updated_at pass-through

### DIFF
--- a/src/domain/user/model/user_model.py
+++ b/src/domain/user/model/user_model.py
@@ -13,9 +13,6 @@ class ProfileVO(BaseModel):
     user_id: int
     name: Optional[str] = ''
     avatar: Optional[str] = ''
-    # Unix epoch seconds; bumped only when the avatar URL actually changes.
-    # Frontend uses this as a cache buster for the stable S3 avatar URL.
-    avatar_updated_at: Optional[int] = None
     job_title: Optional[str] = ''
     company: Optional[str] = ''
     years_of_experience: Optional[str] = '0'
@@ -33,7 +30,6 @@ class ProfileDTO(BaseModel):
     user_id: Optional[int]
     name: Optional[str] = ''
     avatar: Optional[str] = ''
-    avatar_updated_at: Optional[int] = None
     job_title: Optional[str] = ''
     company: Optional[str] = ''
     years_of_experience: Optional[str] = '0'


### PR DESCRIPTION
## 這個 PR 在做什麼

把 `avatar_updated_at` pass-through 從 BFF 拔掉。

之前 #109 在 BFF schema 加這個欄位，是為了把 User service 的 `avatar_updated_at` 透傳給前端當 cache buster。FE 已經改成在上傳當下把 `?v=Date.now()` 直接 bake 進 avatar URL（X-Talent-Frontend#566），這個欄位變成沒人讀的死碼。

## 改了什麼

`src/domain/user/model/user_model.py` 的 `ProfileVO` 跟 `ProfileDTO` 各拿掉 `avatar_updated_at: Optional[int] = None` 一行。純刪除：1 個檔案、`-4` 行。

`SearchMentorProfileVO`、`MentorProfileVO` 走繼承，自動跟著消失，不用單獨改。

## 配套 PR

X-Career-User — `chore/remove-avatar-updated-at`：把 column / DTO / VO / `assign_avatar_updated_at` 整個 stack 拿掉。

部署順序：**BFF（本 PR）→ User**，避免 BFF schema 期望欄位但 User 不再回。

## 已關掉的相關 PR

| PR | 狀態 |
|---|---|
| X-Career-BFF#111（reservation `avatar_updated_at` pass-through）| 已關 |
| X-Career-BFF#112（touch proxy endpoint）| 已關 |
| X-Career-User#78 / #79 / #80 | 已關 |
| X-Career-Search#16 | 已關 |

## Test plan

- [ ] Deploy 到 dev
- [ ] BFF OpenAPI spec 不再列 `avatar_updated_at`
- [ ] `/v1/users/{user_id}/{language}/profile`、`/v1/mentors/{user_id}/{language}/profile`、`/v1/mentors/{user_id}` (search)、`/v1/users/{user_id}/reservations` 等 response 都沒有此欄位
- [ ] FE pnpm generate:types 抓到的 schema 跟著乾淨
- [ ] X-Talent-Frontend#566 上線後，cache busting 行為改由 avatar URL 內的 `?v=` 接手

🤖 Generated with [Claude Code](https://claude.com/claude-code)
