### PR TITLE
feat(#229): proxy v2 user-tags endpoints (BFF)

### DIFF
--- a/src/config/constant.py
+++ b/src/config/constant.py
@@ -78,6 +78,19 @@ class Sorting(Enum):
 class AccountType(Enum):
     XC = 'XC'
     GOOGLE = 'GOOGLE'
+
+
+class TagKind(str, Enum):
+    EXPERTISE = 'expertise'
+    SKILL = 'skill'
+    POSITION = 'position'
+    TOPIC = 'topic'
+    WHAT_I_OFFER = 'what_i_offer'
+
+
+class TagIntent(str, Enum):
+    WANT = 'WANT'
+    OFFER = 'OFFER'
     LINKEDIN = 'LINKEDIN'
 
 

--- a/src/domain/user/model/tag_model.py
+++ b/src/domain/user/model/tag_model.py
@@ -1,0 +1,33 @@
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+from src.config.constant import TagIntent, TagKind
+
+
+class UserTagVO(BaseModel):
+    tag_id: int
+    intent: str
+    kind: str
+    subject_group: Optional[str] = None
+    language: Optional[str] = None
+    subject: Optional[str] = ''
+
+
+class UserTagListVO(BaseModel):
+    user_tags: List[UserTagVO] = []
+
+
+class UserTagsUpsertDTO(BaseModel):
+    kind: TagKind
+    intent: TagIntent
+    subject_groups: List[str] = []
+    language: Optional[str] = None
+
+
+class UserTagsUpsertVO(BaseModel):
+    user_id: int
+    kind: str
+    intent: str
+    tag_ids: List[int] = []
+    replaced: bool = True

--- a/src/domain/user/service/user_service.py
+++ b/src/domain/user/service/user_service.py
@@ -11,6 +11,7 @@ from src.domain.user.model.reservation_model import (
     UpdateReservationDTO,
     ReservationDTO,
 )
+from src.domain.user.model.tag_model import UserTagsUpsertDTO
 from src.domain.user.model.user_model import ProfileDTO
 from src.infra.client.async_service_api_adapter import AsyncServiceApiAdapter
 from src.infra.template.cache import ICache
@@ -88,6 +89,29 @@ class UserService:
 
     async def update_reservation_status(self, reservation_id: int, body: UpdateReservationDTO) -> Dict:
         req_url = f"{USER_SERVICE_URL}/v1/{USERS}/{body.my_user_id}/reservations/{reservation_id}"
+        payload = jsonable_encoder(body)
+        res: Dict = await self.service_api.simple_put(url=req_url, json=payload)
+        return res
+
+    async def get_user_tags(
+        self,
+        user_id: int,
+        kind: Optional[str] = None,
+        intent: Optional[str] = None,
+    ) -> Dict:
+        req_url = f"{USER_SERVICE_URL}/v1/{USERS}/{user_id}/tags"
+        params: Dict[str, Any] = {}
+        if kind is not None:
+            params["kind"] = kind
+        if intent is not None:
+            params["intent"] = intent
+        res: Dict = await self.service_api.simple_get(
+            url=req_url, params=params or None
+        )
+        return res
+
+    async def replace_user_tags(self, user_id: int, body: UserTagsUpsertDTO) -> Dict:
+        req_url = f"{USER_SERVICE_URL}/v1/{USERS}/{user_id}/tags"
         payload = jsonable_encoder(body)
         res: Dict = await self.service_api.simple_put(url=req_url, json=payload)
         return res

--- a/src/router/v1/user.py
+++ b/src/router/v1/user.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 from fastapi import (
     APIRouter,
@@ -15,6 +16,7 @@ from ...domain.user.model import (
     common_model as common,
     user_model as user,
     reservation_model as reservation,
+    tag_model as tag,
 )
 from ...infra.util.util import get_localized_territories_alpha_3
 
@@ -124,3 +126,34 @@ async def update_reservation_status(
     body.my_user_id = user_id
     res: Dict = await _user_service.update_reservation_status(reservation_id, body)
     return res_success(data=res)
+
+
+############################################################################################
+# Unified user tag proxies (#226 / #229). Forwards to User service v2 tag endpoints.
+# Replaces per-kind interest/profession upsert paths once the frontend cuts over.
+############################################################################################
+@router.get('/{user_id}/tags',
+            dependencies=[Depends(verify_path_user_id)],
+            responses=idempotent_response('get_user_tags', tag.UserTagListVO))
+async def get_user_tags(
+        user_id: int = Path(...),
+        kind: Optional[TagKind] = Query(default=None),
+        intent: Optional[TagIntent] = Query(default=None),
+):
+    data: Dict = await _user_service.get_user_tags(
+        user_id,
+        kind=kind.value if kind else None,
+        intent=intent.value if intent else None,
+    )
+    return res_success(data=data)
+
+
+@router.put('/{user_id}/tags',
+            dependencies=[Depends(verify_path_user_id)],
+            responses=idempotent_response('replace_user_tags', tag.UserTagsUpsertVO))
+async def replace_user_tags(
+        user_id: int = Path(...),
+        body: tag.UserTagsUpsertDTO = Body(...),
+):
+    data: Dict = await _user_service.replace_user_tags(user_id, body)
+    return res_success(data=data)


### PR DESCRIPTION
## Summary

BFF passthrough for the unified user-tag API introduced by the User-service half of #229 (PR #85 in X-Career-User). Frontend will hit these BFF endpoints — they forward unchanged to the User service via the existing shared client.

- `GET /user-service/api/v1/users/{user_id}/tags?kind=&intent=`
- `PUT /user-service/api/v1/users/{user_id}/tags`
  Body: `{ kind, intent, subject_groups[], language? }`

## What changed

- **`src/router/v1/user.py`** — two new routes mirroring the `/profile` proxy pattern. Both attach `verify_path_user_id` so the Bearer token must match the path's `user_id` (same auth posture as every other `/users/{user_id}/*` route).
- **`src/domain/user/service/user_service.py`** — `get_user_tags()` / `replace_user_tags()`. Forward via the shared `AsyncServiceApiAdapter`; URL built from `USER_SERVICE_URL`.
- **`src/domain/user/model/tag_model.py`** — `UserTagVO`, `UserTagListVO`, `UserTagsUpsertDTO`, `UserTagsUpsertVO`. Mirrors the User-service models so the BFF validates request bodies + documents responses without leaking transport detail.
- **`src/config/constant.py`** — `TagKind` and `TagIntent` enums with the same values as the User service (`expertise / skill / position / topic / what_i_offer` and `WANT / OFFER`).

## Additive only

Existing `/profile`, `/interests`, `/industries`, `/reservations` proxies are untouched. No behavior change for any v1 caller.

## Test plan

- [ ] `cd X-Talent-infra && docker compose up -d --build` — BFF + User both up
- [ ] Auth: hit `PUT /user-service/api/v1/users/{my_id}/tags` with valid JWT — 200; without/with mismatched token — 401/403
- [ ] `PUT /users/{id}/tags` with `{"kind":"what_i_offer","intent":"OFFER","subject_groups":["career_coaching"]}` returns the User service's `tag_ids` array unchanged
- [ ] `GET /users/{id}/tags?intent=OFFER` returns the inserted tag

Refs Xchange-Taiwan/X-Talent-Tracker#229, Xchange-Taiwan/X-Talent-Tracker#226

Generated with [Claude Code](https://claude.com/claude-code)
