### PR TITLE
fix(#229): restore AccountType.LINKEDIN orphaned by tag enum addition

### DIFF
--- a/src/config/constant.py
+++ b/src/config/constant.py
@@ -78,6 +78,7 @@ class Sorting(Enum):
 class AccountType(Enum):
     XC = 'XC'
     GOOGLE = 'GOOGLE'
+    LINKEDIN = 'LINKEDIN'
 
 
 class TagKind(str, Enum):
@@ -91,7 +92,6 @@ class TagKind(str, Enum):
 class TagIntent(str, Enum):
     WANT = 'WANT'
     OFFER = 'OFFER'
-    LINKEDIN = 'LINKEDIN'
 
 
 class AuthorizeType(Enum):


### PR DESCRIPTION
## Summary

Fixes a regression introduced by PR #116 (`feat(#229): proxy v2 user-tags endpoints (BFF)`).

`AccountType.LINKEDIN` (added previously on `dev`) ended up orphaned inside the new `TagIntent` enum because the Edit that introduced `TagKind` / `TagIntent` only matched the first two `AccountType` values (`XC`, `GOOGLE`). The third value got pushed below the new class and Python parsed it as a `TagIntent` member.

After this fix:

```python
class AccountType(Enum):
    XC = 'XC'
    GOOGLE = 'GOOGLE'
    LINKEDIN = 'LINKEDIN'   # restored


class TagIntent(str, Enum):
    WANT = 'WANT'
    OFFER = 'OFFER'         # only valid intents per the #226 design
```

No callers were relying on `TagIntent.LINKEDIN` — it was a parser accident, not a feature.

## Test plan

- `python -c "from src.config.constant import AccountType, TagIntent; assert AccountType.LINKEDIN.value == 'LINKEDIN'; assert not hasattr(TagIntent, 'LINKEDIN'); print('OK')"`

Refs Xchange-Taiwan/X-Talent-Tracker#229, Xchange-Taiwan/X-Talent-Tracker#226

Generated with [Claude Code](https://claude.com/claude-code)
