### PR TITLE
fix(#229): expose Tag.desc through BFF UserTagVO

### DIFF
--- a/src/domain/user/model/tag_model.py
+++ b/src/domain/user/model/tag_model.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel
 
@@ -12,6 +12,9 @@ class UserTagVO(BaseModel):
     subject_group: Optional[str] = None
     language: Optional[str] = None
     subject: Optional[str] = ''
+    # Free-form per-tag metadata (icon, display hints, etc.) — mirrors the
+    # User service Tag.desc JSONB column. Pass-through here.
+    desc: Optional[Dict[str, Any]] = None
 
 
 class UserTagListVO(BaseModel):


### PR DESCRIPTION
Mirrors User PR #87 — passes the per-tag desc field through the proxy. Without this, the BFF would strip desc on its way to the frontend even though the User service now returns it.

Refs Xchange-Taiwan/X-Talent-Tracker#229, Xchange-Taiwan/X-Talent-Tracker#226