### PR TITLE
feat(#226): align BFF MentorProfileVO.user_tags to UserTagBucketsVO

### DIFF
--- a/src/domain/mentor/model/mentor_model.py
+++ b/src/domain/mentor/model/mentor_model.py
@@ -2,7 +2,7 @@ from pydantic import Field
 
 from .experience_model import ExperienceVO
 from ...user.model.common_model import ProfessionListVO
-from ...user.model.tag_model import UserTagVO
+from ...user.model.tag_model import UserTagBucketsVO
 from ...user.model.user_model import *
 from ....config.constant import *
 
@@ -27,10 +27,9 @@ class MentorProfileVO(ProfileVO):
     seniority_level: Optional[SeniorityLevel] = SeniorityLevel.NO_REVEAL
     expertises: Optional[ProfessionListVO] = None
     experiences: Optional[List[ExperienceVO]] = Field(default_factory=list)
-    # #226 two-layer: hydrated unified user-tags array (with parent_subject_group).
-    # Mirrors the new field on User-service MentorProfileVO so the BFF passes
-    # it through unchanged.
-    user_tags: Optional[List[UserTagVO]] = None
+    # #226 two-layer: pre-grouped per-(kind, intent) buckets, mirroring
+    # User-service MentorProfileVO so the BFF passes it through unchanged.
+    user_tags: Optional[UserTagBucketsVO] = None
 
 
 class TimeSlotDTO(BaseModel):

--- a/src/domain/user/model/tag_model.py
+++ b/src/domain/user/model/tag_model.py
@@ -24,6 +24,22 @@ class UserTagListVO(BaseModel):
     user_tags: List[UserTagVO] = []
 
 
+class UserTagBucketsVO(BaseModel):
+    """Pre-grouped view of a user's tags, mirroring User-service shape so the
+    BFF can pass the response through unchanged. Bucket → (kind, intent):
+      want_skills    → (skill,    WANT)   "想多了解、加強的技能"
+      offer_skills   → (skill,    OFFER)  "我能教的 expertise"
+      want_topics    → (topic,    WANT)   "想多了解的主題"
+      offer_topics   → (topic,    OFFER)  "我能聊的主題"
+      want_positions → (position, WANT)   "有興趣多了解的職位"
+    """
+    want_skills: List[UserTagVO] = []
+    offer_skills: List[UserTagVO] = []
+    want_topics: List[UserTagVO] = []
+    offer_topics: List[UserTagVO] = []
+    want_positions: List[UserTagVO] = []
+
+
 class UserTagsUpsertDTO(BaseModel):
     kind: TagKind
     intent: TagIntent


### PR DESCRIPTION
## Summary
- User-service `mentor_profile` now returns `user_tags` as a per-(kind, intent) buckets dict (`UserTagBucketsVO`). BFF was still typed as `List[UserTagVO]` (flat) — runtime was unaffected because BFF passes the User-service dict through unchanged, but the swagger / type hint was lying.
- Add `UserTagBucketsVO` mirror in BFF `tag_model.py` (no `from_flat` — BFF never constructs buckets, only passes them through).
- Switch `MentorProfileVO.user_tags` to `Optional[UserTagBucketsVO]` and update the comment to match.

No runtime behavior change. Pairs with `Xchange-Taiwan/X-Career-User#89` which is the source of the new shape.

## Test plan
- [ ] BFF starts cleanly (no import errors from the new model).
- [ ] Once X-Career-User#89 is deployed to dev, hit the BFF mentor-profile passthrough and confirm the `user_tags` dict has the buckets keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)