### PR TITLE
feat(#226): mirror UserTagBucketsInputDTO + user_tags on MentorProfileDTO

### DIFF
--- a/src/domain/mentor/model/mentor_model.py
+++ b/src/domain/mentor/model/mentor_model.py
@@ -2,7 +2,7 @@ from pydantic import Field
 
 from .experience_model import ExperienceVO
 from ...user.model.common_model import ProfessionListVO
-from ...user.model.tag_model import UserTagBucketsVO
+from ...user.model.tag_model import UserTagBucketsInputDTO, UserTagBucketsVO
 from ...user.model.user_model import *
 from ....config.constant import *
 
@@ -16,6 +16,10 @@ class MentorProfileDTO(ProfileDTO):
     about: Optional[str] = None
     seniority_level: Optional[SeniorityLevel] = SeniorityLevel.NO_REVEAL
     expertises: Optional[List[str]] = None
+    # #226 Option B: optional buckets-shaped input that User-service
+    # writes to user_tags atomically with the rest of the profile. BFF
+    # passes through unchanged.
+    user_tags: Optional[UserTagBucketsInputDTO] = None
 
     class Config:
         from_attributes = True

--- a/src/domain/user/model/tag_model.py
+++ b/src/domain/user/model/tag_model.py
@@ -45,13 +45,17 @@ class UserTagBucketsInputDTO(BaseModel):
     nested field on PUT mentor_profile so caller can write multiple buckets
     in one shot. None per bucket = leave alone, [] = clear, [...] = replace
     with these LEAF subject_groups. BFF passes the dict through unchanged.
+
+    Language is intentionally not in this shape — User-service always uses
+    the user's profile language to avoid forking selections across languages
+    given the current single-table tag schema. See User-service
+    UserTagBucketsInputDTO docstring for the full reasoning.
     """
     want_skills: Optional[List[str]] = None
     offer_skills: Optional[List[str]] = None
     want_topics: Optional[List[str]] = None
     offer_topics: Optional[List[str]] = None
     want_positions: Optional[List[str]] = None
-    language: Optional[str] = None
 
 
 class UserTagsUpsertDTO(BaseModel):

--- a/src/domain/user/model/tag_model.py
+++ b/src/domain/user/model/tag_model.py
@@ -40,6 +40,20 @@ class UserTagBucketsVO(BaseModel):
     want_positions: List[UserTagVO] = []
 
 
+class UserTagBucketsInputDTO(BaseModel):
+    """Input mirror of User-service `UserTagBucketsInputDTO`. Used as a
+    nested field on PUT mentor_profile so caller can write multiple buckets
+    in one shot. None per bucket = leave alone, [] = clear, [...] = replace
+    with these LEAF subject_groups. BFF passes the dict through unchanged.
+    """
+    want_skills: Optional[List[str]] = None
+    offer_skills: Optional[List[str]] = None
+    want_topics: Optional[List[str]] = None
+    offer_topics: Optional[List[str]] = None
+    want_positions: Optional[List[str]] = None
+    language: Optional[str] = None
+
+
 class UserTagsUpsertDTO(BaseModel):
     kind: TagKind
     intent: TagIntent


### PR DESCRIPTION
## Summary
Pairs with `Xchange-Taiwan/X-Career-User#feat/226-mentor-profile-write-tags` (Option B): PUT mentor_profile now accepts an optional `user_tags` buckets payload that User-service writes atomically with the legacy profile fields.

- Add `UserTagBucketsInputDTO` mirror so swagger / type hint matches the request shape User-service expects (BFF passes the dict through unchanged at runtime).
- `MentorProfileDTO.user_tags: Optional[UserTagBucketsInputDTO]`.

No runtime behavior change in BFF.

## Test plan
- [ ] BFF starts cleanly (no import errors from the new model).
- [ ] Once the User-service PR is deployed, confirm swagger shows `user_tags` on the BFF PUT endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)