### PR TITLE
chore(#226): trim feature-branch comments to load-bearing WHY only

### DIFF
--- a/src/config/constant.py
+++ b/src/config/constant.py
@@ -82,9 +82,6 @@ class AccountType(Enum):
 
 
 class TagKind(str, Enum):
-    # `expertise` and `what_i_offer` were collapsed into `skill` / `topic`
-    # under the #226 two-layer redesign — intent flag (WANT vs OFFER)
-    # disambiguates mentee wants vs mentor offerings.
     SKILL = 'skill'
     POSITION = 'position'
     TOPIC = 'topic'

--- a/src/domain/mentor/model/mentor_model.py
+++ b/src/domain/mentor/model/mentor_model.py
@@ -16,9 +16,6 @@ class MentorProfileDTO(ProfileDTO):
     about: Optional[str] = None
     seniority_level: Optional[SeniorityLevel] = SeniorityLevel.NO_REVEAL
     expertises: Optional[List[str]] = None
-    # #226 Option B: optional buckets-shaped input that User-service
-    # writes to user_tags atomically with the rest of the profile. BFF
-    # passes through unchanged.
     user_tags: Optional[UserTagBucketsInputDTO] = None
 
     class Config:
@@ -31,8 +28,6 @@ class MentorProfileVO(ProfileVO):
     seniority_level: Optional[SeniorityLevel] = SeniorityLevel.NO_REVEAL
     expertises: Optional[ProfessionListVO] = None
     experiences: Optional[List[ExperienceVO]] = Field(default_factory=list)
-    # #226 two-layer: pre-grouped per-(kind, intent) buckets, mirroring
-    # User-service MentorProfileVO so the BFF passes it through unchanged.
     user_tags: Optional[UserTagBucketsVO] = None
 
 

--- a/src/domain/user/model/tag_model.py
+++ b/src/domain/user/model/tag_model.py
@@ -12,11 +12,8 @@ class UserTagVO(BaseModel):
     subject_group: Optional[str] = None
     language: Optional[str] = None
     subject: Optional[str] = ''
-    # Free-form per-tag metadata (icon, display hints, etc.) — mirrors the
-    # User service Tag.desc JSONB column. Pass-through here.
     desc: Optional[Dict[str, Any]] = None
-    # Two-layer hierarchy (#226): NULL on top-level group / industry rows,
-    # non-NULL on leaf rows. Mirrors User-service Tag.parent_subject_group.
+    # NULL on top-level group rows, non-NULL on leaf rows.
     parent_subject_group: Optional[str] = None
 
 
@@ -25,14 +22,7 @@ class UserTagListVO(BaseModel):
 
 
 class UserTagBucketsVO(BaseModel):
-    """Pre-grouped view of a user's tags, mirroring User-service shape so the
-    BFF can pass the response through unchanged. Bucket → (kind, intent):
-      want_skills    → (skill,    WANT)   "想多了解、加強的技能"
-      offer_skills   → (skill,    OFFER)  "我能教的 expertise"
-      want_topics    → (topic,    WANT)   "想多了解的主題"
-      offer_topics   → (topic,    OFFER)  "我能聊的主題"
-      want_positions → (position, WANT)   "有興趣多了解的職位"
-    """
+    """Pre-grouped view of a user's tags, one bucket per (kind, intent)."""
     want_skills: List[UserTagVO] = []
     offer_skills: List[UserTagVO] = []
     want_topics: List[UserTagVO] = []
@@ -41,16 +31,10 @@ class UserTagBucketsVO(BaseModel):
 
 
 class UserTagBucketsInputDTO(BaseModel):
-    """Input mirror of User-service `UserTagBucketsInputDTO`. Used as a
-    nested field on PUT mentor_profile so caller can write multiple buckets
-    in one shot. None per bucket = leave alone, [] = clear, [...] = replace
-    with these LEAF subject_groups. BFF passes the dict through unchanged.
-
-    Language is intentionally not in this shape — User-service always uses
-    the user's profile language to avoid forking selections across languages
-    given the current single-table tag schema. See User-service
-    UserTagBucketsInputDTO docstring for the full reasoning.
-    """
+    """Per bucket: None = leave alone, [] = clear, [...] = replace with these
+    LEAF subject_groups. Language is intentionally omitted — User-service
+    always uses the user's profile language to avoid forked selections
+    across languages."""
     want_skills: Optional[List[str]] = None
     offer_skills: Optional[List[str]] = None
     want_topics: Optional[List[str]] = None
@@ -96,8 +80,5 @@ class TagCatalogVO(BaseModel):
 
 
 class TagCatalogsVO(BaseModel):
-    """Multi-kind catalog wrapper, mirror of User-service shape. Callers
-    always consume `data.catalogs[kind]` regardless of how many kinds the
-    request filtered for."""
     language: str
     catalogs: Dict[str, TagCatalogVO] = {}

--- a/src/domain/user/model/user_model.py
+++ b/src/domain/user/model/user_model.py
@@ -25,8 +25,6 @@ class ProfileVO(BaseModel):
     onboarding: Optional[bool] = False
     is_mentor: Optional[bool] = False
     language: Optional[str] = DEFAULT_LANGUAGE
-    # #226: hydrated user-tags (mirror of User-service ProfileVO so BFF
-    # passes the buckets dict through unchanged).
     user_tags: Optional[UserTagBucketsVO] = None
 
 
@@ -44,8 +42,6 @@ class ProfileDTO(BaseModel):
     industry: Optional[str] = ''
     language: Optional[str] = DEFAULT_LANGUAGE
     is_mentor: Optional[bool] = False
-    # #226 Option B (mentee parity): optional buckets-shaped input that
-    # User-service writes atomically with the profile. BFF passes through.
     user_tags: Optional[UserTagBucketsInputDTO] = None
 
     model_config = {

--- a/src/domain/user/service/user_service.py
+++ b/src/domain/user/service/user_service.py
@@ -96,10 +96,8 @@ class UserService:
     async def get_tag_catalog(
         self, language: str, kinds: Optional[List[str]] = None
     ) -> Dict:
-        # `kinds` None / [] = all kinds. Forwarded as repeated `?kind=skill&
-        # kind=topic` query params; User-service returns the unified
-        # TagCatalogsVO shape regardless.
         req_url = f"{USER_SERVICE_URL}/v1/{USERS}/{language}/tags/catalog"
+        # List value becomes repeated `?kind=skill&kind=topic` query params.
         params = {'kind': kinds} if kinds else None
         res: Dict = await self.service_api.simple_get(url=req_url, params=params)
         return res

--- a/src/router/v1/user.py
+++ b/src/router/v1/user.py
@@ -128,21 +128,13 @@ async def update_reservation_status(
     return res_success(data=res)
 
 
-############################################################################################
-# Tag catalog proxy (#226). The standalone GET/PUT /{user_id}/tags pair was
-# removed: callers now read user_tags from the hydrated `user_tags` field on
-# GET /mentor_profile (mentor) or GET /users/profile (mentee), and write via
-# the buckets payload on the corresponding PUT.
-############################################################################################
 @router.get('/{language}/tags/catalog',
             responses=idempotent_response('get_tag_catalog', tag.TagCatalogsVO))
 async def get_tag_catalog(
         language: str = Path(...),
         kind: Optional[List[TagKind]] = Query(default=None),
 ):
-    # Multi-kind: pass `?kind=skill&kind=topic`, or omit to fetch all
-    # supported kinds in one round-trip. Response is uniform
-    # TagCatalogsVO regardless of how many kinds were requested.
+    # Pass `?kind=skill&kind=topic`, or omit `kind` to fetch all kinds.
     kind_values = [k.value for k in kind] if kind else None
     data: Dict = await _user_service.get_tag_catalog(language, kind_values)
     return res_success(data=data)


### PR DESCRIPTION
## Summary
Pure comment / docstring cleanup. Same criteria as X-Career-User cleanup PR — removed ticket refs, "BFF passes through" annotations, cross-repo pointers, history blocks. Kept `language`-intentionally-omitted reasoning, `parent_subject_group` invariant, FastAPI list-as-repeated-query-param note in proxy.

No code semantics changed. Pre-existing comments untouched.

Pairs with `Xchange-Taiwan/X-Career-User#chore/226-clean-comments`.

## Test plan
- [ ] BFF starts cleanly (no import errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)