### PR TITLE
feat(reservation): add company to RUserInfoVO

### DIFF
--- a/src/domain/user/model/reservation_model.py
+++ b/src/domain/user/model/reservation_model.py
@@ -75,6 +75,7 @@ class RUserInfoVO(BaseModel):
     name: Optional[str] = ''
     avatar: Optional[str] = ''
     job_title: Optional[str] = ''
+    company: Optional[str] = ''
     years_of_experience: Optional[str] = '0'
 
 


### PR DESCRIPTION
## Summary
- Add `company` to `RUserInfoVO` so the BFF schema mirrors the User service.
- Schema-only change; no logic touched.

Pairs with Xchange-Taiwan/X-Career-User#94.

## Test plan
- [ ] Once both PRs are deployed, hit reservation endpoints through BFF and confirm `sender` / `participant` carry `company` and `job_title`.