### PR TITLE
feat(#226): mirror 5 top-level tag buckets, drop user_tags wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ node_modules
 venv
 **/**__pycache__
 **.db
+.DS_Store
+**/.DS_Store
 
 test2/
 

--- a/src/config/constant.py
+++ b/src/config/constant.py
@@ -81,6 +81,12 @@ class AccountType(Enum):
     LINKEDIN = 'LINKEDIN'
 
 
+class TagKind(str, Enum):
+    SKILL = 'skill'
+    POSITION = 'position'
+    TOPIC = 'topic'
+
+
 class AuthorizeType(Enum):
     SIGNUP = 'SIGNUP'
     LOGIN = 'LOGIN'

--- a/src/domain/mentor/model/mentor_model.py
+++ b/src/domain/mentor/model/mentor_model.py
@@ -2,6 +2,7 @@ from pydantic import Field
 
 from .experience_model import ExperienceVO
 from ...user.model.common_model import ProfessionListVO
+from ...user.model.tag_model import TagVO
 from ...user.model.user_model import *
 from ....config.constant import *
 
@@ -16,6 +17,15 @@ class MentorProfileDTO(ProfileDTO):
     seniority_level: Optional[SeniorityLevel] = SeniorityLevel.NO_REVEAL
     expertises: Optional[List[str]] = None
 
+    # Per-bucket replace: None = leave alone, [] = clear, [...] = replace.
+    # Each entry is a leaf subject_group; User-service validates against the
+    # tags catalog and aggregates into want_tags / have_tags before storage.
+    want_position: Optional[List[str]] = None
+    want_skill: Optional[List[str]] = None
+    want_topic: Optional[List[str]] = None
+    have_skill: Optional[List[str]] = None
+    have_topic: Optional[List[str]] = None
+
     class Config:
         from_attributes = True
 
@@ -26,6 +36,14 @@ class MentorProfileVO(ProfileVO):
     seniority_level: Optional[SeniorityLevel] = SeniorityLevel.NO_REVEAL
     expertises: Optional[ProfessionListVO] = None
     experiences: Optional[List[ExperienceVO]] = Field(default_factory=list)
+
+    # Hydrated by User-service: each TagVO carries subject + desc +
+    # parent_subject_group from the catalog.
+    want_position: Optional[List[TagVO]] = None
+    want_skill: Optional[List[TagVO]] = None
+    want_topic: Optional[List[TagVO]] = None
+    have_skill: Optional[List[TagVO]] = None
+    have_topic: Optional[List[TagVO]] = None
 
 
 class TimeSlotDTO(BaseModel):

--- a/src/domain/user/model/tag_model.py
+++ b/src/domain/user/model/tag_model.py
@@ -1,0 +1,42 @@
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+class TagVO(BaseModel):
+    """Mirror of X-Career-User TagVO. Each enriched bucket on
+    MentorProfileVO is a list of these."""
+    id: int
+    kind: str
+    subject_group: Optional[str] = None
+    language: Optional[str] = None
+    subject: Optional[str] = ''
+    desc: Optional[Dict[str, Any]] = None
+    parent_subject_group: Optional[str] = None
+
+
+class TagCatalogLeafVO(BaseModel):
+    tag_id: int
+    subject_group: str
+    subject: str
+    language: str
+    desc: Optional[Dict[str, Any]] = None
+
+
+class TagCatalogGroupVO(BaseModel):
+    subject_group: str
+    subject: str
+    language: str
+    desc: Optional[Dict[str, Any]] = None
+    leaves: List[TagCatalogLeafVO] = []
+
+
+class TagCatalogVO(BaseModel):
+    kind: str
+    language: str
+    groups: List[TagCatalogGroupVO] = []
+
+
+class TagCatalogsVO(BaseModel):
+    language: str
+    catalogs: Dict[str, TagCatalogVO] = {}

--- a/src/domain/user/model/user_model.py
+++ b/src/domain/user/model/user_model.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field
 from .common_model import ProfessionVO, InterestListVO
 from ....config.conf import DEFAULT_LANGUAGE
 
-log = logging.getLogger(__name__) 
+log = logging.getLogger(__name__)
 
 
 class ProfileVO(BaseModel):

--- a/src/domain/user/service/user_service.py
+++ b/src/domain/user/service/user_service.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Dict, Any
+from typing import List, Optional, Dict, Any
 
 from fastapi.encoders import jsonable_encoder
 
@@ -90,4 +90,13 @@ class UserService:
         req_url = f"{USER_SERVICE_URL}/v1/{USERS}/{body.my_user_id}/reservations/{reservation_id}"
         payload = jsonable_encoder(body)
         res: Dict = await self.service_api.simple_put(url=req_url, json=payload)
+        return res
+
+    async def get_tag_catalog(
+        self, language: str, kinds: Optional[List[str]] = None
+    ) -> Dict:
+        req_url = f"{USER_SERVICE_URL}/v1/{USERS}/{language}/tags/catalog"
+        # List value becomes repeated `?kind=skill&kind=topic` query params.
+        params = {'kind': kinds} if kinds else None
+        res: Dict = await self.service_api.simple_get(url=req_url, params=params)
         return res

--- a/src/router/v1/user.py
+++ b/src/router/v1/user.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List, Optional
 
 from fastapi import (
     APIRouter,
@@ -15,6 +16,7 @@ from ...domain.user.model import (
     common_model as common,
     user_model as user,
     reservation_model as reservation,
+    tag_model as tag,
 )
 from ...infra.util.util import get_localized_territories_alpha_3
 
@@ -124,3 +126,15 @@ async def update_reservation_status(
     body.my_user_id = user_id
     res: Dict = await _user_service.update_reservation_status(reservation_id, body)
     return res_success(data=res)
+
+
+@router.get('/{language}/tags/catalog',
+            responses=idempotent_response('get_tag_catalog', tag.TagCatalogsVO))
+async def get_tag_catalog(
+        language: str = Path(...),
+        kind: Optional[List[TagKind]] = Query(default=None),
+):
+    # Pass `?kind=skill&kind=topic`, or omit `kind` to fetch all kinds.
+    kind_values = [k.value for k in kind] if kind else None
+    data: Dict = await _user_service.get_tag_catalog(language, kind_values)
+    return res_success(data=data)


### PR DESCRIPTION
## Summary
Mirrors X-Career-User contract: `MentorProfileDTO/VO` carry `want_position`, `want_skill`, `want_topic`, `have_skill`, `have_topic` at the top level instead of a nested `user_tags` wrapper. `TagIntent` enum dropped (decorative on BFF).

**Do NOT merge — testing pending.** Only `python -m py_compile` was run.

Pairs with X-Career-User and X-Career-Search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)