### PR TITLE
chore(#226): drop legacy profession surface — BFF

### DIFF
--- a/src/config/constant.py
+++ b/src/config/constant.py
@@ -6,10 +6,6 @@ class Language(Enum):
     ZH_TW = 'zh_TW'
 
 
-class ProfessionCategory(Enum):
-    INDUSTRY = 'INDUSTRY'
-
-
 class ExperienceCategory(Enum):
     WORK = 'WORK'
     EDUCATION = 'EDUCATION'

--- a/src/domain/user/model/common_model.py
+++ b/src/domain/user/model/common_model.py
@@ -1,33 +1,9 @@
 import logging
-from typing import List, Optional
+from typing import List
 
 from pydantic import BaseModel
 
-from ....config.constant import *
-
 log = logging.getLogger(__name__)
-
-
-class MetadataVO(BaseModel):
-    desc: Optional[str] = None
-    icon: Optional[str] = None
-
-
-class ProfessionDTO(BaseModel):
-    id: int
-    category: ProfessionCategory
-    language: Optional[str]
-
-
-class ProfessionVO(ProfessionDTO):
-    subject_group: str = 'unknown'
-    subject: str = ''
-    profession_metadata: MetadataVO = MetadataVO()
-    language: Optional[str] = ''
-
-
-class ProfessionListVO(BaseModel):
-    professions: List[ProfessionVO] = []
 
 
 class CountryVO(BaseModel):

--- a/src/domain/user/model/user_model.py
+++ b/src/domain/user/model/user_model.py
@@ -1,9 +1,8 @@
 import logging
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
-from .common_model import ProfessionVO
 from ....config.conf import DEFAULT_LANGUAGE
 
 log = logging.getLogger(__name__)
@@ -17,7 +16,10 @@ class ProfileVO(BaseModel):
     company: Optional[str] = ''
     years_of_experience: Optional[str] = '0'
     location: Optional[str] = ''
-    industry: Optional[ProfessionVO] = None
+    # BFF is a proxy — industry is passed through unmodified from the
+    # User service (TagVO shape, kind='industry'). Not modeled here on
+    # purpose: that detail belongs to the upstream contract.
+    industry: Optional[Dict[str, Any]] = None
     onboarding: Optional[bool] = False
     is_mentor: Optional[bool] = False
     language: Optional[str] = DEFAULT_LANGUAGE

--- a/src/domain/user/service/user_service.py
+++ b/src/domain/user/service/user_service.py
@@ -3,9 +3,9 @@ from typing import Optional, Dict, Any
 
 from fastapi.encoders import jsonable_encoder
 
-from src.config.conf import USER_SERVICE_URL, DEFAULT_LANGUAGE, CACHE_TTL
-from src.config.constant import Language, USERS
-from src.config.exception import NotFoundException, raise_http_exception
+from src.config.conf import USER_SERVICE_URL, DEFAULT_LANGUAGE
+from src.config.constant import USERS
+from src.config.exception import NotFoundException
 from src.domain.user.model.reservation_model import (
     ReservationQueryDTO,
     UpdateReservationDTO,
@@ -36,27 +36,6 @@ class UserService:
         req_url = f"{USER_SERVICE_URL}/v1/{USERS}/profile"
         res: Optional[Dict[str, Any]] = await self.service_api.simple_put(url=req_url, json=data.model_dump())
         return res
-
-    async def get_industries(self, language: Language) -> Dict:
-        try:
-            cache_key = self.cache_key(f"professions:INDUSTRY", language.value)
-            cache_val = await self.local_cache.get(cache_key)
-            if cache_val:
-                return cache_val
-
-            req_url = f"{USER_SERVICE_URL}/v1/{USERS}/{language.value}/industries"
-            res: Dict = await self.service_api.simple_get(url=req_url)
-            # set cache
-            await self.local_cache.set(cache_key, res, CACHE_TTL)
-            return res
-
-        except Exception as e:
-            log.error(e)
-            raise_http_exception(e, 'Internal Server Error')
-
-    def cache_key(self, category: str, language: str):
-        return f"{category}:{language}"
-
 
     async def get_reservation_list(self, user_id: int, query: ReservationQueryDTO) -> Dict:
         req_url = f"{USER_SERVICE_URL}/v1/{USERS}/{user_id}/reservations"

--- a/src/router/v1/user.py
+++ b/src/router/v1/user.py
@@ -52,15 +52,6 @@ async def get_profile(
     return res_success(data=jsonable_encoder(data))
 
 
-@router.get('/{language}/industries',
-            responses=idempotent_response('get_industries', common.ProfessionListVO))
-async def get_industries(
-        language: Language = Path(...)
-):
-    data: Dict = await _user_service.get_industries(language)
-    return res_success(data=jsonable_encoder(data))
-
-
 @router.get('/{language}/countries',
             responses=idempotent_response('get_countries', common.CountryListVO))
 async def get_countries(


### PR DESCRIPTION
## What Does This PR Do?

Cross-repo follow-up to X-Career-User PR #106. Removes the BFF-side
copies of the legacy ProfessionVO surface that are no longer reachable
once the User service stops returning them.

Deleted:
- `ProfessionDTO` / `ProfessionVO` / `ProfessionListVO` (and the
  internal `MetadataVO` they used)
- `ProfessionCategory` python enum
- `GET /users/{language}/industries` BFF endpoint
- `UserService.get_industries` and `UserService.cache_key` (only ever
  used by the deleted endpoint)
- Now-unused imports in `user_service.py` (`Language`, `CACHE_TTL`,
  `raise_http_exception`)

API contract change:
- `ProfileVO.industry` changes from `Optional[ProfessionVO]` to
  `Optional[Dict[str, Any]]` — BFF is a proxy, so the actual TagVO
  shape (kind='industry') from the User service passes through
  unmodified. Frontend-relevant fields (`subject`, `subject_group`)
  are unchanged on the wire.

Untouched:
- `filter_industries` query parameter (`/search/...`) — that's a
  search filter, separate from the catalog model and unaffected by
  this cleanup
- `UserService.cache` / `UserService.local_cache` instance fields —
  no longer used inside this class, but other DI patterns may rely
  on the constructor signature; left for a future cleanup

## How to Test

```
# (1) start BFF
docker compose up -d bff

# (2) /industries should be gone
curl -o /dev/null -w "%{http_code}\n" \
    http://127.0.0.1:8000/api/v1/users/en_US/industries
# expected: 404

# (3) profile passthrough — industry comes back as the User service's
#     TagVO shape (kind='industry'), not ProfessionVO
curl -H "Authorization: Bearer <jwt>" \
    http://127.0.0.1:8000/api/v1/users/<uid>/en_US/profile
```

## Anything to Note?

- **Depends on X-Career-User PR #106** (`chore(#226): drop legacy
  profession surface — User service`). Merge that first; otherwise
  the User service is still serving ProfessionVO and the BFF's new
  `Dict[str, Any]` annotation will silently still validate (because
  Dict is permissive), but you'll get inconsistent shape on the wire
  in production until both ship.
- **Cross-repo follow-up**: X-Career-Search has its own ProfessionVO
  copies — separate PR will follow.
- **Frontend impact**: any frontend reader of `ProfileVO.industry`
  that strictly typed it as ProfessionVO will need to relax to TagVO
  (or `unknown`). Practical fields used today (`subject`,
  `subject_group`) are unchanged.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
