### PR TITLE
feat: mirror experiences field on MentorProfileDTO

### DIFF
--- a/src/domain/mentor/model/mentor_model.py
+++ b/src/domain/mentor/model/mentor_model.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
-from .experience_model import ExperienceVO
+from .experience_model import ExperienceDTO, ExperienceVO
 from ...user.model.user_model import ProfileDTO, ProfileVO
 from ....config.constant import (
     ScheduleType,
@@ -20,6 +20,11 @@ class MentorProfileDTO(ProfileDTO):
     personal_statement: Optional[str] = None
     about: Optional[str] = None
     seniority_level: Optional[SeniorityLevel] = SeniorityLevel.NO_REVEAL
+
+    # Inline experiences batch — see X-Career-User MentorProfileDTO for
+    # replace semantics. Mirrored here so BFF doesn't strip the field
+    # when proxying via model_dump.
+    experiences: Optional[List[ExperienceDTO]] = None
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
## Summary
- Adds the optional `experiences` batch field on BFF`s `MentorProfileDTO` so the body forwarded to X-Career-User retains the field after `model_dump`. See [X-Career-User PR](https://github.com/Xchange-Taiwan/X-Career-User/pulls) for replace semantics (`None` = leave alone, `[]` = clear, `[...]` = replace as the new full set).

## Test plan
- [x] Pair-tested with X-Career-User branch via docker compose; PUT `/mentors/{id}/profile` with inline `experiences` round-trips correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)