### PR TITLE
refactor(schedule): mirror meeting_duration_minutes on schedule DTOs

### DIFF
--- a/src/domain/mentor/model/mentor_model.py
+++ b/src/domain/mentor/model/mentor_model.py
@@ -43,6 +43,10 @@ class TimeSlotDTO(BaseModel):
     rrule: Optional[str] = Field(default=None, example="FREQ=WEEKLY;COUNT=4")
     timezone: str = Field(default="UTC", example="UTC")
     exdate: List[Optional[int]] = Field(default=[], example=[1718413200, 1719622800])
+    # New-format marker mirrored from X-Career-User. NULL = legacy
+    # MINUTELY-rrule row; set = (dtstart, dtend) is block, divided into
+    # sub-slots of this length. Must flow through unchanged.
+    meeting_duration_minutes: Optional[int] = Field(default=None, example=30)
 
 
 class MentorScheduleDTO(BaseModel):
@@ -68,6 +72,7 @@ class MentorScheduleSegmentVO(BaseModel):
     rrule: Optional[str] = Field(default=None, example="FREQ=WEEKLY;COUNT=4")
     timezone: str = Field(default="UTC", example="UTC")
     exdate: List[Optional[int]] = Field(default=[], example=[1718413200, 1719622800])
+    meeting_duration_minutes: Optional[int] = Field(default=None, example=30)
     source: str = Field(..., example="schedule")
     source_id: Optional[int] = Field(default=None, example=100)
 


### PR DESCRIPTION
## Summary

Pass-through change so the new `meeting_duration_minutes` field added to X-Career-User flows end-to-end. Without this, BFF would silently drop the field on PUT requests (Pydantic strips undeclared fields via `model_dump()`) and not surface it on GET responses.

Companion PRs (must deploy together):
- X-Career-User: column + validation + backfill
- Frontend: switch to (block, meeting_duration) representation

## Test plan

- [ ] Deploy alongside the X-Career-User PR
- [ ] PUT `/v1/mentors/{id}/schedule` from frontend with `meeting_duration_minutes` — verify field reaches User service (check User logs / DB)
- [ ] GET `/v1/mentors/{id}/schedule/y/{y}/m/{m}` — verify `meeting_duration_minutes` is in `segments[*]` of the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)