### PR TITLE
fix: add 5 tag bucket fields to MentorProfileVO/DTO (Tracker#252)

### DIFF
--- a/src/domain/mentor/model/mentor_model.py
+++ b/src/domain/mentor/model/mentor_model.py
@@ -21,6 +21,15 @@ class MentorProfileDTO(ProfileDTO):
     about: Optional[str] = None
     seniority_level: Optional[SeniorityLevel] = SeniorityLevel.NO_REVEAL
 
+    # Per bucket: None = leave alone, [] = clear, [...] = replace.
+    # Values are leaf subject_groups validated server-side against the
+    # tags catalog. Matches X-Career-User MentorProfileDTO.
+    want_position: Optional[List[str]] = None
+    want_skill: Optional[List[str]] = None
+    want_topic: Optional[List[str]] = None
+    have_skill: Optional[List[str]] = None
+    have_topic: Optional[List[str]] = None
+
     class Config:
         from_attributes = True
 
@@ -30,6 +39,15 @@ class MentorProfileVO(ProfileVO):
     about: Optional[str] = ""
     seniority_level: Optional[SeniorityLevel] = SeniorityLevel.NO_REVEAL
     experiences: Optional[List[ExperienceVO]] = Field(default_factory=list)
+
+    # Bucketed tag subject_groups, mirroring X-Career-User MentorProfileVO.
+    # Values are flat subject_group canonical keys; frontend resolves display
+    # metadata from the tag catalog. None = not bucketed; [] = empty.
+    want_position: Optional[List[str]] = None
+    want_skill: Optional[List[str]] = None
+    want_topic: Optional[List[str]] = None
+    have_skill: Optional[List[str]] = None
+    have_topic: Optional[List[str]] = None
 
 
 class TimeSlotDTO(BaseModel):


### PR DESCRIPTION
## Summary
- Add `want_position` / `want_skill` / `want_topic` / `have_skill` / `have_topic` to `MentorProfileVO` and `MentorProfileDTO` as `Optional[List[str]] = None`, mirroring `X-Career-User` since #226 (User PR #97 + #108).
- **VO**: dict already passes through, but BFF `/openapi.json` didn't expose the fields, so frontend `pnpm generate:types` produced `TagVO[]` (pre-#108 shape) and the consumer in `useUserData.ts:74-82 toTagDisplay()` processes new `string[]` payload as `TagVO[]`, silently rendering empty arrays.
- **DTO**: Pydantic actively dropped the fields from incoming PUT bodies, so frontend updates of the 5 buckets never reached User service. This one is a real silent fail.

## Test plan
- [x] `docker compose -f X-Talent-infra/docker-compose.yml restart bff` → BFF reloads cleanly
- [x] `GET http://localhost:8006/openapi.json` → both `MentorProfileVO` and `MentorProfileDTO` now expose 5 fields as `array of string` (nullable)
- [ ] Once merged + deployed, frontend runs `pnpm generate:types` and `src/types/api.ts` updates to `string[] | null`
- [ ] Frontend follow-up (Tracker#254) rewrites `toTagDisplay` to handle `string[]` + resolve display labels via tag catalog

Refs Xchange-Taiwan/X-Talent-Tracker#252

🤖 Generated with [Claude Code](https://claude.com/claude-code)