### PR TITLE
refactor(experiences): drop single-experience proxy, mirror inline batch

### DIFF
--- a/src/domain/mentor/model/experience_model.py
+++ b/src/domain/mentor/model/experience_model.py
@@ -9,31 +9,15 @@ log = logging.getLogger(__name__)
 
 
 class ExperienceDTO(BaseModel):
-    id: Optional[int] = None
     category: ExperienceCategory = None
     mentor_experiences_metadata: Dict[str, Any] = {}
     order: int = 0
 
 
 class ExperienceVO(BaseModel):
-    id: int
     category: ExperienceCategory = None
     mentor_experiences_metadata: Dict[str, Any] = {}
     order: int = 0
-
-    @staticmethod
-    def of(
-        exp_id: int,
-        category: ExperienceCategory,
-        mentor_experiences_metadata: Dict[str, Any],
-        order: int,
-    ) -> "ExperienceVO":
-        return ExperienceVO(
-            id=exp_id,
-            category=category,
-            mentor_experiences_metadata=mentor_experiences_metadata,
-            order=order,
-        )
 
 
 class ExperienceListVO(BaseModel):

--- a/src/domain/mentor/model/mentor_model.py
+++ b/src/domain/mentor/model/mentor_model.py
@@ -30,6 +30,12 @@ class MentorProfileDTO(ProfileDTO):
     have_skill: Optional[List[str]] = None
     have_topic: Optional[List[str]] = None
 
+    # Experiences travel inline with the profile PUT — same three-state
+    # semantics as the tag buckets (None = leave alone, [] = clear,
+    # [...] = replace as the new full set). Mirrors X-Career-User which
+    # stores them as JSONB[] on profiles.experiences.
+    experiences: Optional[List[ExperienceVO]] = None
+
     class Config:
         from_attributes = True
 

--- a/src/domain/mentor/service/mentor_service.py
+++ b/src/domain/mentor/service/mentor_service.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Optional, Dict, Any
 
-from ..model.experience_model import ExperienceVO, ExperienceDTO
 from ..model.mentor_model import (
     MentorProfileDTO,
     MentorProfileVO,
@@ -10,7 +9,7 @@ from ..model.mentor_model import (
     MentorScheduleDTO,
 )
 from ....config.conf import USER_SERVICE_URL, DEFAULT_LANGUAGE, CACHE_TTL
-from ....config.constant import MENTORS, ExperienceCategory, Language
+from ....config.constant import MENTORS, Language
 from ....config.exception import NotFoundException, raise_http_exception
 from ....infra.client.async_service_api_adapter import AsyncServiceApiAdapter
 from ....infra.template.cache import ICache
@@ -42,31 +41,6 @@ class MentorService:
             url=req_url, json=data.model_dump(mode='json'),
         )
         return res
-
-    async def upsert_experience(self, data: ExperienceDTO, user_id: int, experience_type: str, is_mentor: bool) -> ExperienceVO:
-        req_url = f"{USER_SERVICE_URL}/v1/{MENTORS}/{user_id}/experiences/{experience_type}"
-
-        payload = data.model_dump()
-        payload.update({"category": experience_type})
-        headers = {"is_mentor": str(is_mentor).lower()}
-        res: Optional[ServiceApiResponse] = await self.service_api.put(
-            url=req_url, json=payload, headers=headers
-        )
-        res_data = res.data
-
-        return ExperienceVO.of(res_data.get('id'),
-                               ExperienceCategory(res_data.get('category')),
-                               res_data.get('mentor_experiences_metadata'),
-                               res_data.get('order'))
-
-    async def delete_experience(self, user_id: int, exp_cate: str, exp_id: int, is_mentor: bool) -> bool:
-        req_url = f"{USER_SERVICE_URL}/v1/{MENTORS}/{user_id}/experiences/{exp_cate}/{exp_id}"
-
-        headers = {"is_mentor": str(is_mentor).lower()}
-        res: Optional[ServiceApiResponse] = await self.service_api.delete(
-            url=req_url, headers=headers
-        )
-        return res.data
 
     def cache_key(self, category: str, language: str):
         return f"{category}:{language}"

--- a/src/router/v1/mentor.py
+++ b/src/router/v1/mentor.py
@@ -3,18 +3,15 @@ from typing import List
 
 from fastapi import (
     APIRouter,
-    Header, Path, Query, Body, Depends,
+    Path, Query, Body, Depends,
 )
 from fastapi.encoders import jsonable_encoder
 
 from ..req.authorization import verify_jwt_access, verify_path_user_id
 from src.app._di.injection import _mentor_service
-from src.config.constant import ExperienceCategory, Language
+from src.config.constant import Language
 from src.config.exception import *
-from src.domain.mentor.model import (
-    mentor_model as mentor,
-    experience_model as experience,
-)
+from src.domain.mentor.model import mentor_model as mentor
 from src.domain.user.model import (
     common_model as common,
 )
@@ -68,36 +65,6 @@ async def get_universities(
     if not data:
         raise ClientException(msg='There are no universities in this country!')
     res = common.UniversityListVO(universities=data).model_dump()
-    return res_success(data=res)
-
-
-@router.put('/{user_id}/experiences/{experience_type}',
-            dependencies=[Depends(verify_path_user_id)],
-            responses=idempotent_response('upsert_experience', experience.ExperienceVO))
-async def upsert_experience(
-        is_mentor: bool = Header(False),
-        user_id: int = Path(...),
-        experience_type: ExperienceCategory = Path(...),
-        body: experience.ExperienceDTO = Body(...),
-):
-    res: experience.ExperienceVO = await _mentor_service.upsert_experience(
-        body, user_id, experience_type.value, is_mentor
-    )
-    return res_success(data=jsonable_encoder(res))
-
-
-@router.delete('/{user_id}/experiences/{experience_type}/{experience_id}',
-               dependencies=[Depends(verify_path_user_id)],
-               responses=idempotent_response('delete_experience', experience.ExperienceVO))
-async def delete_experience(
-        is_mentor: bool = Header(False),
-        user_id: int = Path(...),
-        experience_type: ExperienceCategory = Path(...),
-        experience_id: int = Path(...),
-):
-    res: bool = await _mentor_service.delete_experience(
-        user_id, experience_type.value, experience_id, is_mentor
-    )
     return res_success(data=res)
 
 


### PR DESCRIPTION
## Summary
- Adds the optional `experiences` field on `MentorProfileDTO` so PUT `/mentors/{id}/profile` carries the full experiences set through to X-Career-User.
- Drops the now-unbacked `PUT/DELETE /mentors/{id}/experiences` proxy endpoints, the matching `MentorService` methods, and the per-experience `id` field from `ExperienceVO/DTO`.

Supersedes PR #135.

## Coordinated changes
- X-Career-User PR #114: backing storage moves to `profiles.experiences` JSONB[]; the single-experience endpoints this proxy targeted are gone.
- X-Career-Search PR #33: drops the `PATCH_MENTOR_PROFILE` action; fixes the empty-array overwrite bug on the OpenSearch side.
- X-Talent-Frontend PR: switches to inline experiences on the profile PUT.

## Test plan
- [x] BFF still type-checks / Python compiles cleanly after dropping `upsert_experience` / `delete_experience` methods.
- [x] Integration verified through the User service (BFF is a thin proxy; the inline `experiences` field round-trips when forwarded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)