### PR TITLE
fix(#226): restore /tags/catalog proxy dropped in bfaf6a9

### DIFF
--- a/src/config/constant.py
+++ b/src/config/constant.py
@@ -74,6 +74,17 @@ class AuthorizeType(Enum):
     LOGIN = 'LOGIN'
 
 
+class TagKind(Enum):
+    # Mirrors X-Career-User's TagKind. The 5 mentor profile buckets are
+    # (kind × array): want_tags carries position/skill/topic; have_tags
+    # carries skill/topic. INDUSTRY is flat (stored on profiles.industry,
+    # not in want_tags/have_tags).
+    SKILL = 'skill'
+    POSITION = 'position'
+    TOPIC = 'topic'
+    INDUSTRY = 'industry'
+
+
 # Session/cache 欄位與 HttpOnly Cookie 名稱（與 OAuth 2.0 RFC 6749 參數名一致）
 REFRESH_TOKEN_KEY = 'refresh_token'
 

--- a/src/domain/user/model/tag_model.py
+++ b/src/domain/user/model/tag_model.py
@@ -1,0 +1,42 @@
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+class TagVO(BaseModel):
+    id: int
+    kind: str
+    subject_group: Optional[str] = None
+    language: Optional[str] = None
+    subject: Optional[str] = ''
+    desc: Optional[Dict[str, Any]] = None
+    parent_subject_group: Optional[str] = None
+
+    model_config = {"from_attributes": True}
+
+
+class TagCatalogLeafVO(BaseModel):
+    tag_id: int
+    subject_group: str
+    subject: str
+    language: str
+    desc: Optional[Dict[str, Any]] = None
+
+
+class TagCatalogGroupVO(BaseModel):
+    subject_group: str
+    subject: str
+    language: str
+    desc: Optional[Dict[str, Any]] = None
+    leaves: List[TagCatalogLeafVO] = []
+
+
+class TagCatalogVO(BaseModel):
+    kind: str
+    language: str
+    groups: List[TagCatalogGroupVO] = []
+
+
+class TagCatalogsVO(BaseModel):
+    language: str
+    catalogs: Dict[str, TagCatalogVO] = {}

--- a/src/domain/user/service/user_service.py
+++ b/src/domain/user/service/user_service.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 
 from fastapi.encoders import jsonable_encoder
 
@@ -35,6 +35,18 @@ class UserService:
     async def upsert_user_profile(self, data: ProfileDTO) -> Optional[Dict[str, Any]]:
         req_url = f"{USER_SERVICE_URL}/v1/{USERS}/profile"
         res: Optional[Dict[str, Any]] = await self.service_api.simple_put(url=req_url, json=data.model_dump())
+        return res
+
+    async def get_tag_catalog(
+        self,
+        language: str,
+        kinds: Optional[List[str]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        req_url = f"{USER_SERVICE_URL}/v1/{USERS}/{language}/tags/catalog"
+        # httpx serializes a list value as repeated query keys (?kind=skill&kind=topic),
+        # which matches the upstream `Optional[List[TagKind]]` Query signature.
+        params = {"kind": kinds} if kinds else None
+        res: Optional[Dict[str, Any]] = await self.service_api.simple_get(url=req_url, params=params)
         return res
 
     async def get_reservation_list(self, user_id: int, query: ReservationQueryDTO) -> Dict:

--- a/src/router/v1/user.py
+++ b/src/router/v1/user.py
@@ -66,7 +66,7 @@ async def get_countries(
 @router.get('/{language}/tags/catalog',
             responses=idempotent_response('get_tag_catalog', tag.TagCatalogsVO))
 async def get_tag_catalog(
-        language: Language = Path(...),
+        language: Language = Path(default=Language.ZH_TW),
         kind: Optional[List[TagKind]] = Query(default=None),
 ):
     kinds = [k.value for k in kind] if kind else None

--- a/src/router/v1/user.py
+++ b/src/router/v1/user.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List, Optional
 
 from fastapi import (
     APIRouter,
@@ -15,6 +16,7 @@ from ...domain.user.model import (
     common_model as common,
     user_model as user,
     reservation_model as reservation,
+    tag_model as tag,
 )
 from ...infra.util.util import get_localized_territories_alpha_3
 
@@ -59,6 +61,17 @@ async def get_countries(
 ):
     data: Dict = get_localized_territories_alpha_3(language)
     return res_success(data=data)
+
+
+@router.get('/{language}/tags/catalog',
+            responses=idempotent_response('get_tag_catalog', tag.TagCatalogsVO))
+async def get_tag_catalog(
+        language: Language = Path(...),
+        kind: Optional[List[TagKind]] = Query(default=None),
+):
+    kinds = [k.value for k in kind] if kind else None
+    res: Dict = await _user_service.get_tag_catalog(language.value, kinds)
+    return res_success(data=res)
 
 
 @router.get('/{user_id}/reservations',


### PR DESCRIPTION
## Summary
- Restore `GET /v1/users/{language}/tags/catalog` proxy on BFF (originally added in 79b9754, deleted in bfaf6a9 under the wrong assumption of "no consumers post-cleanup").
- Frontend has been calling this endpoint via BFF the whole time — both SSR (`services/profile/tagCatalog.server.ts:19`) and client (`services/profile/tagCatalog.ts:60`) — so without this proxy, FE 404s after the next dev redeploy.
- Re-introduces `TagKind` enum, `tag_model.py` (mirror of User-service VOs), `UserService.get_tag_catalog`, and the route. Optional multi-value `?kind=` is preserved.

## Why this was missed
`bfaf6a9` was a legitimate cleanup of the legacy fragmented tag surface (`/interests`, `/expertises`, etc.), but the unified `/tags/catalog` from the new two-layer redesign was bundled in alongside the legacy DTOs and dropped together. They look similar but serve very different purposes — the unified catalog read is the foundation of the v2 picker, not legacy.

## Test plan
- [ ] Local: BFF imports cleanly (no `from typing import List` / `tag_model` resolution issues)
- [ ] Local or dev: `curl ".../dev/v1/users/en_US/tags/catalog"` returns the same payload as direct call to User service `gvjbxpuqmh`
- [ ] `?kind=skill&kind=topic` filter forwards correctly (httpx serializes list as repeated keys)
- [ ] BFF Swagger at `fg4592kuq1.../dev/docs#/User` shows the new endpoint after `npm run serverless:deploy:xchange:dev`
- [ ] FE `tagCatalog.server.ts` SSR fetch returns non-empty catalog against deployed BFF

🤖 Generated with [Claude Code](https://claude.com/claude-code)