### PR TITLE
fix: BFF Lambda 502 — Path() default crashes app init

### DIFF
--- a/src/router/v1/user.py
+++ b/src/router/v1/user.py
@@ -66,7 +66,7 @@ async def get_countries(
 @router.get('/{language}/tags/catalog',
             responses=idempotent_response('get_tag_catalog', tag.TagCatalogsVO))
 async def get_tag_catalog(
-        language: Language = Path(default=Language.ZH_TW),
+        language: Language = Path(..., example=Language.ZH_TW),
         kind: Optional[List[TagKind]] = Query(default=None),
 ):
     kinds = [k.value for k in kind] if kind else None


### PR DESCRIPTION
## Summary

- `Path(default=Language.ZH_TW)` in PR #142's swagger commit (`68ccfa6`) trips FastAPI's `Path parameters cannot have a default value` assert at module import, crashing the BFF Lambda cold start and returning 502 on every route on dev (`/dev/docs`, `/dev/openapi.json`, `/dev/api/*`).
- Path is required by URL semantics so it can't carry a default. Switch to `Path(..., example=Language.ZH_TW)` — Swagger UI pre-fills the "Try it out" input from the OpenAPI example, preserving the original UX intent without breaking app init.

## Test plan

- [x] Local import + `app.openapi()` succeeds; param schema includes `"example": "zh_TW"`
- [ ] Deploy to dev (`npm run serverless:deploy:xchange:dev`) and verify:
  - [ ] `GET /dev/docs` renders Swagger UI
  - [ ] `GET /dev/openapi.json` returns 200
  - [ ] `GET /dev/api/v1/users/zh_TW/tags/catalog` returns 200
  - [ ] Swagger "Try it out" on `/users/{language}/tags/catalog` pre-fills `language=zh_TW`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
