### PR TITLE
fix(deploy): restore BFF Lambda env vars wiped by d4a1784

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,42 @@
+# Used by deploy.sh to substitute ${env:KEY} placeholders in serverless.yml.
+# Copy to .env.<stage> (e.g. .env.dev) and fill with stage-specific values.
+
+# AWS deployment targets
 THE_REGION=ap-northeast-1
 STAGE=dev
 ACCOUNT_ID=123456789012
+
+# DynamoDB / S3 resources
 TABLE_CACHE=cache
 XC_USER_BUCKET=x-bucket
+XC_BUCKET=x-career-bff-<stage>-serverlessdeploymentbucket-<suffix>
+
+# Application defaults
+DEFAULT_LANGUAGE=zh_TW
+TESTING=<stage>
+BATCH=10
+
+# Cache TTLs (seconds)
+REQUEST_INTERVAL_TTL=8
+SHORT_TERM_TTL=1800
+LONG_TERM_TTL=259200
+CACHE_TTL=300
+
+# JWT
+JWT_ALGORITHM=HS256
+ACCESS_TOKEN_TTL=1800
+REFRESH_TOKEN_TTL=2592000
+AUTH_RESPONSE_FIELDS=oauth_id;account_type;region;online
+
+# Upstream micro-services (API Gateway URLs)
+AUTH_SERVICE_URL=https://<id>.execute-api.<region>.amazonaws.com/<stage>/auth-service/api
+USER_SERVICE_URL=https://<id>.execute-api.<region>.amazonaws.com/<stage>/user-service/api
+SEARCH_SERVICE_URL=https://<id>.execute-api.<region>.amazonaws.com/<stage>/search-service/api
+
+# Frontend redirect for Google OAuth
+FRONTEND_REDIRECT_URL=https://<frontend-host>/auth/google/callback/redirect
+
+# Image upload limits
+MAX_WIDTH=300
+MAX_HEIGHT=300
+MAX_STORAGE_SIZE=15728640

--- a/serverless.yml
+++ b/serverless.yml
@@ -135,9 +135,33 @@ functions:
     memorySize: 256
     environment:
       STAGE: ${self:provider.stage}
-      # S3 相關環境變數
+      TESTING: ${env:TESTING}
+      DEFAULT_LANGUAGE: ${env:DEFAULT_LANGUAGE}
+      # S3 / storage
+      XC_BUCKET: ${env:XC_BUCKET}
       XC_USER_BUCKET: ${env:XC_USER_BUCKET}
       S3_REGION: ${self:provider.region}
+      MAX_WIDTH: ${env:MAX_WIDTH}
+      MAX_HEIGHT: ${env:MAX_HEIGHT}
+      MAX_STORAGE_SIZE: ${env:MAX_STORAGE_SIZE}
+      # DynamoDB cache table + TTLs
+      TABLE_CACHE: ${env:TABLE_CACHE}
+      BATCH: ${env:BATCH}
+      REQUEST_INTERVAL_TTL: ${env:REQUEST_INTERVAL_TTL}
+      SHORT_TERM_TTL: ${env:SHORT_TERM_TTL}
+      LONG_TERM_TTL: ${env:LONG_TERM_TTL}
+      CACHE_TTL: ${env:CACHE_TTL}
+      # JWT
+      JWT_ALGORITHM: ${env:JWT_ALGORITHM}
+      ACCESS_TOKEN_TTL: ${env:ACCESS_TOKEN_TTL}
+      REFRESH_TOKEN_TTL: ${env:REFRESH_TOKEN_TTL}
+      AUTH_RESPONSE_FIELDS: ${env:AUTH_RESPONSE_FIELDS}
+      # Upstream micro-services
+      AUTH_SERVICE_URL: ${env:AUTH_SERVICE_URL}
+      USER_SERVICE_URL: ${env:USER_SERVICE_URL}
+      SEARCH_SERVICE_URL: ${env:SEARCH_SERVICE_URL}
+      # Frontend redirect for Google OAuth
+      FRONTEND_REDIRECT_URL: ${env:FRONTEND_REDIRECT_URL}
     layers:
     - {Ref: PythonRequirementsLambdaLayer}
     events:


### PR DESCRIPTION
## Summary

- `d4a1784` (chore: remove unused params, 2026-05-05) deleted `dev-env-deploy.sh` thinking it was unused. It wasn't — that script pushed 19 environment variables to the BFF Lambda after every deploy, including `USER_SERVICE_URL`, `AUTH_SERVICE_URL`, `SEARCH_SERVICE_URL`, JWT settings, and cache TTLs.
- `sls deploy` replaces Lambda env vars with whatever's in `serverless.yml`'s `environment:` block — which only had `STAGE` / `XC_USER_BUCKET` / `S3_REGION`. After d4a1784, every redeploy wiped the rest. `USER_SERVICE_URL` fell back to `http://127.0.0.1:8010/...`, surfaced as `code:50000 / "All connection attempts failed"` on any route that proxies to upstream services.
- Wire the missing 19 vars directly into `serverless.yml` `functions.app.environment`, sourced from `.env.dev` via the existing `${env:KEY}` / sed substitution flow in `deploy.sh`. Env vars now survive `sls deploy` without needing a side-channel `aws lambda update-function-configuration` step.
- `.env.example` updated to document the required keys for new contributors.

## Why this approach over restoring `dev-env-deploy.sh`

The deleted script ran `aws lambda update-function-configuration --environment` after `sls deploy` — fragile because: (a) requires AWS CLI on every deployer's machine, (b) hardcodes URLs in a shell script, (c) can be silently lost again. Putting the same values in `.env.dev` + `serverless.yml` gives `sls deploy` ownership of the Lambda env in one shot, and the keys are reviewable in `.env.example`.

## Test plan

- [x] `.env.dev` populated locally; `${env:KEY}` references in `serverless.yml` all resolve (24/24, no missing keys)
- [x] Upstream User service URL `gvjbxpuqmh...` confirmed alive via curl (`/v1/users/zh_TW/tags/catalog` reaches User Lambda, no DNS/connection error)
- [ ] After merge: `npm run serverless:deploy:xchange:dev`, then verify:
  - [ ] `aws lambda get-function-configuration --function-name x-career-bff-dev-app --query Environment.Variables` shows all 24 vars
  - [ ] `GET /dev/api/v1/users/zh_TW/tags/catalog` returns 200 (no more `All connection attempts failed`)
  - [ ] `GET /dev/docs` still loads (regression check vs PR #143)

## Notes

- `JWT_SECRET`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `REDIS_*` are read in `src/config/conf.py` but **were not** in `dev-env-deploy.sh` either — out of scope here. If auth flows are broken in dev, that's a pre-existing gap to triage separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
