### PR TITLE
Revert PR #133: dev-env-deploy.sh was not unused

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ test2/
 **.env*
 
 !deploy.sh
+!dev-env-deploy.sh
 !.env.example
 
 

--- a/dev-env-deploy.sh
+++ b/dev-env-deploy.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# 取得 AWS 帳號別名，默認為 "default"
+AWS_PROFILE="default"
+
+# 解析命令行选项
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -a|--account) AWS_PROFILE="$2"; REGION=$(aws configure get region --profile "$2"); shift ;; # 指定 AWS 帳號；重新取得該帳號 region
+        *) echo "未知选项: $1"; exit 1 ;;  # 处理未知选项
+    esac
+    shift
+done
+
+aws lambda update-function-configuration --function-name x-career-bff-dev-app --environment --profile $AWS_PROFILE "Variables={
+DEFAULT_LANGUAGE=zh_TW,
+STAGE=dev,
+TESTING=dev,
+XC_BUCKET=x-career-bff-dev-serverlessdeploymentbucket-zndkgowobwsz,
+XC_USER_BUCKET=x-career-multimedia,
+BATCH=10,
+REQUEST_INTERVAL_TTL=8,
+SHORT_TERM_TTL=1800,
+LONG_TERM_TTL=259200,
+JWT_ALGORITHM=HS256,
+ACCESS_TOKEN_TTL=1800,
+REFRESH_TOKEN_TTL=2592000,
+AUTH_RESPONSE_FIELDS=oauth_id;account_type;region;online,
+CACHE_TTL=300,
+TABLE_CACHE=dev_x_career_bff_cache,
+AUTH_SERVICE_URL=https://d11k5l9gl6.execute-api.ap-northeast-1.amazonaws.com/dev/auth-service/api,
+USER_SERVICE_URL=https://gvjbxpuqmh.execute-api.ap-northeast-1.amazonaws.com/dev/user-service/api,
+SEARCH_SERVICE_URL=https://qa9af3a6vf.execute-api.ap-northeast-1.amazonaws.com/dev/search-service/api,
+FRONTEND_REDIRECT_URL=https://xtalent.vercel.app/auth/google/callback/redirect,
+MAX_WIDTH=300,
+MAX_HEIGHT=300,
+MAX_STORAGE_SIZE=15728640,
+}"


### PR DESCRIPTION
## Summary

Revert PR #133 (`chore(params): remove unused params`, merged 2026-05-04).

`dev-env-deploy.sh` was not unused. It runs after `sls deploy` to push 19 environment variables (`USER_SERVICE_URL`, `AUTH_SERVICE_URL`, `SEARCH_SERVICE_URL`, JWT settings, cache TTLs, etc.) to the BFF Lambda via `aws lambda update-function-configuration`.

`sls deploy` replaces the Lambda environment with whatever's in `serverless.yml`'s `environment:` block — which only carries `STAGE` / `XC_USER_BUCKET` / `S3_REGION`. After this script was deleted, the next deploy wiped the rest. `USER_SERVICE_URL` fell back to the local-dev default `http://127.0.0.1:8010/...`, surfacing as `code:50000 / "All connection attempts failed"` on any BFF route that proxies upstream.

This is a pure revert — restores the script + the `!dev-env-deploy.sh` whitelist line in `.gitignore`. No architectural change.

## Test plan

- [ ] After merge: `npm run serverless:deploy:xchange:dev`
- [ ] Then: `./dev-env-deploy.sh --account default` (requires AWS CLI)
- [ ] Verify `aws lambda get-function-configuration --function-name x-career-bff-dev-app --query Environment.Variables` lists all 22 vars
- [ ] `GET /dev/api/v1/users/zh_TW/tags/catalog` returns 200 (no more `All connection attempts failed`)
- [ ] `GET /dev/docs` still loads (regression check vs PR #143)

## Future direction (out of scope)

If the team wants to remove the side-channel script properly, the right path is to migrate secrets to AWS SSM Parameter Store / Secrets Manager and reference them from `serverless.yml` as `${ssm:/...}` — separate PR, separate review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
