### PR TITLE
fix(ci): wait for Lambda update before patching env vars

### DIFF
--- a/.github/workflows/cicd-dev.yaml
+++ b/.github/workflows/cicd-dev.yaml
@@ -48,6 +48,13 @@ jobs:
           TABLE_CACHE: ${{ secrets.TABLE_CACHE }}
           XC_USER_BUCKET: ${{ secrets.XC_USER_BUCKET }}
 
+      # Block until Lambda's CloudFormation rollout has fully settled.
+      # Without this, `update-function-configuration` below can race the
+      # in-progress deploy and get its env vars overwritten when the
+      # rollout finishes with serverless.yml's (smaller) environment block.
+      - name: Wait for Lambda update to settle
+        run: aws lambda wait function-updated --function-name x-career-bff-dev-app
+
       - name: Update Lambda environment variables
         run: |
           aws lambda update-function-configuration \


### PR DESCRIPTION
## Summary

Insert `aws lambda wait function-updated` between the `sls deploy` step and the `update-function-configuration` step in `cicd-dev.yaml`, so the env-var patch doesn't race a still-rolling-out CloudFormation update.

## Root cause

The CI workflow has two consecutive Lambda-touching steps:

1. **`npx sls deploy`** — CloudFormation build using `serverless.yml`'s env block (only `STAGE` / `XC_USER_BUCKET` / `S3_REGION`).
2. **`aws lambda update-function-configuration`** — overlays the full 19-key env block (`USER_SERVICE_URL`, `AUTH_SERVICE_URL`, JWT settings, cache TTLs, etc.).

`sls deploy` returns when CloudFormation reports stack-level completion, but the Lambda function itself can still be in `LastUpdateStatus: InProgress`. The CI log for PR #143's merge run shows it:

```
"LastUpdateStatus": "InProgress",
"LastUpdateStatusReason": "The function is being created.",
"LastUpdateStatusReasonCode": "Creating",
```

When the function finishes its rollout *after* step 2, the env block from step 1 (3 keys) wins — wiping the 19 keys step 2 just set. `USER_SERVICE_URL` ends up unset on the Lambda, so BFF falls back to its `http://127.0.0.1:8010/...` localhost default, and every route that proxies User/Auth/Search returns `code:50000 / "All connection attempts failed"`.

This is what users hit on dev today — `/api/v1/users/zh_TW/tags/catalog` was failing with a connection error even though `/docs` and `/openapi.json` were back up after PR #143.

## Why this is the right fix (vs. alternatives)

- **Reverting PR #133** (restoring `dev-env-deploy.sh`): doesn't actually solve anything — CI/CD already runs the same `update-function-configuration` inline; the script was redundant.
- **Moving env vars into `serverless.yml`**: works, but it's an architectural change beyond the scope of "fix the dev outage." Saved as a future cleanup if we want to remove the side-channel update step entirely.
- **`aws lambda wait function-updated`**: one CLI step, zero architectural change, addresses the actual race.

## Test plan

- [ ] Merge → CI/CD runs on push to dev → log shows the new "Wait for Lambda update to settle" step blocking until function exits `InProgress`
- [ ] Subsequent `Update Lambda environment variables` step succeeds with `LastUpdateStatus: Successful` (not `InProgress`)
- [ ] `aws lambda get-function-configuration --function-name x-career-bff-dev-app --query Environment.Variables` shows all 19 vars after CI/CD finishes
- [ ] `GET /dev/api/v1/users/zh_TW/tags/catalog` returns 200 (or upstream User-service error, but no longer `All connection attempts failed`)
- [ ] `GET /dev/docs` still loads (regression check vs. PR #143)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
