### PR TITLE
fix(auth): grace window for rotated refresh_token to prevent race 401s

### DIFF
--- a/src/config/conf.py
+++ b/src/config/conf.py
@@ -27,6 +27,11 @@ JWT_ALGORITHM = os.getenv('JWT_ALGORITHM', 'HS256')
 ACCESS_TOKEN_TTL = int(os.getenv('ACCESS_TOKEN_TTL', 1800))
 # default = 30 days (30 * 86400 secs)
 REFRESH_TOKEN_TTL = int(os.getenv('REFRESH_TOKEN_TTL', 2592000))
+# Grace window after refresh_token rotation during which the just-rotated
+# refresh_token is still accepted (returns the freshly minted pair) so that
+# concurrent /v1/auth/token callers racing on the same starting token all
+# converge instead of one winning and the rest receiving 401 invalid_grant.
+REFRESH_TOKEN_GRACE_TTL = int(os.getenv('REFRESH_TOKEN_GRACE_TTL', 10))
 
 # filter auth response fields
 AUTH_RESPONSE_FIELDS = os.getenv('AUTH_RESPONSE_FIELDS', 'oauth_id;account_type;region;online')

--- a/src/domain/auth/service/auth_service.py
+++ b/src/domain/auth/service/auth_service.py
@@ -402,16 +402,14 @@ class AuthService:
         auth_res: Dict,
         removed_fields: Set = set(),
         revoke_previous_refresh: Optional[str] = None,
-        grace_previous_refresh: Optional[str] = None,
     ) -> Optional[str]:
         """寫入快取並從 auth_res 剔除敏感欄位。若 removed_fields 含 refresh_token，回傳該值供 auth_response 設 HttpOnly cookie。
 
-        並維護 Redis `rt:{refresh}` -> user_id_key，供 OAuth refresh grant 查詢。
-        登入/登出時傳 ``revoke_previous_refresh`` 立即撤銷舊索引；
-        OAuth refresh rotation 改傳 ``grace_previous_refresh``，將舊索引改寫為短期
-        ``{'replaced_by': new_rt, 'user_id_key': ...}`` 標記，讓 race 中仍持舊 rt 的
-        並行請求在 grace 窗口內也能換到同一份新 token，而不是 401 invalid_grant。
+        並維護 Redis `rt:{refresh}` -> user_id_key，供 OAuth refresh grant 查詢；輪替或重登時傳 revoke_previous_refresh 撤銷舊索引。
         """
+        if revoke_previous_refresh:
+            await self.cache.delete(_refresh_token_index_key(revoke_previous_refresh))
+
         auth_res.update({
             'online': True,
             REFRESH_TOKEN_KEY: gen_refresh_token(),
@@ -430,16 +428,6 @@ class AuthService:
             user_id_key,
             ex=LONG_TERM_TTL,
         )
-
-        # 新 rt 已 commit 後再處理舊 rt: index，避免並行讀者看到尚未生效的 replaced_by。
-        if revoke_previous_refresh:
-            await self.cache.delete(_refresh_token_index_key(revoke_previous_refresh))
-        elif grace_previous_refresh:
-            await self.cache.set(
-                _refresh_token_index_key(grace_previous_refresh),
-                {'replaced_by': new_refresh, 'user_id_key': user_id_key},
-                ex=REFRESH_TOKEN_GRACE_TTL,
-            )
 
         # remove sensitive data: 'aid' & removed_fields
         to_remove = set(removed_fields)
@@ -466,21 +454,9 @@ class AuthService:
         if not cached:
             raise UnauthorizedException(msg='invalid_grant')
 
-        # Grace path: 舊 rt 已在 rotation 視窗內，直接拿 user 當下的 token pair 回應，
-        # 不再 rotate。'replaced_by' 留作除錯線索，定位用 user_id_key。
-        if isinstance(cached, dict) and 'replaced_by' in cached:
-            user_id_key = cached.get('user_id_key')
-            user = await self.cache.get(user_id_key) if user_id_key else None
-            if not user or REFRESH_TOKEN_KEY not in user:
-                raise UnauthorizedException(msg='invalid_grant')
-            res = self.apply_token(user)
-            current_rt = user.get(REFRESH_TOKEN_KEY)
-            auth_res = {k: res[k] for k in ['user_id', 'token'] if k in res}
-            if current_rt:
-                auth_res[REFRESH_TOKEN_KEY] = current_rt
-            return {
-                'auth': auth_res,
-            }
+        # Grace path: rotation 視窗內，直接回 rotation 當下存的 pair。
+        if isinstance(cached, dict) and 'auth' in cached:
+            return {'auth': cached['auth']}
 
         # Normal path: cached 是 user_id_key 字串
         user_id_key = cached
@@ -493,19 +469,21 @@ class AuthService:
         if cached_refresh_token != refresh_token or not valid_refresh_token(cached_refresh_token):
             raise UnauthorizedException(msg='invalid_grant')
 
-        await self.cache_auth_res(
-            user_id_key,
-            user,
-            grace_previous_refresh=refresh_token,
-        )
+        await self.cache_auth_res(user_id_key, user)
         res = self.apply_token(user)
         new_rt = user.get(REFRESH_TOKEN_KEY)
         auth_res = {k: res[k] for k in ['user_id', 'token'] if k in res}
         if new_rt:
             auth_res[REFRESH_TOKEN_KEY] = new_rt
-        return {
-            'auth': auth_res,
-        }
+
+        # 把舊 rt: 改寫成 grace marker，內含 rotation 當下的完整回應。
+        await self.cache.set(
+            _refresh_token_index_key(refresh_token),
+            {'auth': auth_res},
+            ex=REFRESH_TOKEN_GRACE_TTL,
+        )
+
+        return {'auth': auth_res}
 
     '''
     logout

--- a/src/domain/auth/service/auth_service.py
+++ b/src/domain/auth/service/auth_service.py
@@ -402,14 +402,16 @@ class AuthService:
         auth_res: Dict,
         removed_fields: Set = set(),
         revoke_previous_refresh: Optional[str] = None,
+        grace_previous_refresh: Optional[str] = None,
     ) -> Optional[str]:
         """寫入快取並從 auth_res 剔除敏感欄位。若 removed_fields 含 refresh_token，回傳該值供 auth_response 設 HttpOnly cookie。
 
-        並維護 Redis `rt:{refresh}` -> user_id_key，供 OAuth refresh grant 查詢；輪替或重登時傳 revoke_previous_refresh 撤銷舊索引。
+        並維護 Redis `rt:{refresh}` -> user_id_key，供 OAuth refresh grant 查詢。
+        登入/登出時傳 ``revoke_previous_refresh`` 立即撤銷舊索引；
+        OAuth refresh rotation 改傳 ``grace_previous_refresh``，將舊索引改寫為短期
+        ``{'replaced_by': new_rt, 'user_id_key': ...}`` 標記，讓 race 中仍持舊 rt 的
+        並行請求在 grace 窗口內也能換到同一份新 token，而不是 401 invalid_grant。
         """
-        if revoke_previous_refresh:
-            await self.cache.delete(_refresh_token_index_key(revoke_previous_refresh))
-
         auth_res.update({
             'online': True,
             REFRESH_TOKEN_KEY: gen_refresh_token(),
@@ -429,6 +431,16 @@ class AuthService:
             ex=LONG_TERM_TTL,
         )
 
+        # 新 rt 已 commit 後再處理舊 rt: index，避免並行讀者看到尚未生效的 replaced_by。
+        if revoke_previous_refresh:
+            await self.cache.delete(_refresh_token_index_key(revoke_previous_refresh))
+        elif grace_previous_refresh:
+            await self.cache.set(
+                _refresh_token_index_key(grace_previous_refresh),
+                {'replaced_by': new_refresh, 'user_id_key': user_id_key},
+                ex=REFRESH_TOKEN_GRACE_TTL,
+            )
+
         # remove sensitive data: 'aid' & removed_fields
         to_remove = set(removed_fields)
         to_remove.add('aid')
@@ -444,11 +456,34 @@ class AuthService:
     '''
 
     async def get_new_token_pair(self, refresh_token: str) -> Dict:
-        """OAuth 2.0 refresh_token grant：僅依 refresh_token 查 session 並輪替 refresh（rotation）。"""
-        user_id_key = await self.cache.get(_refresh_token_index_key(refresh_token))
-        if not user_id_key:
+        """OAuth 2.0 refresh_token grant：僅依 refresh_token 查 session 並輪替 refresh（rotation）。
+
+        舊 rt 在 rotation 後仍會被改寫為短期 grace 標記
+        (``REFRESH_TOKEN_GRACE_TTL`` 秒)，這段時間內 race 過來的並行呼叫
+        會直接拿到剛產生的新 pair 而不再多輪一輪，避免一贏多輸的 401。
+        """
+        cached = await self.cache.get(_refresh_token_index_key(refresh_token))
+        if not cached:
             raise UnauthorizedException(msg='invalid_grant')
 
+        # Grace path: 舊 rt 已在 rotation 視窗內，直接拿 user 當下的 token pair 回應，
+        # 不再 rotate。'replaced_by' 留作除錯線索，定位用 user_id_key。
+        if isinstance(cached, dict) and 'replaced_by' in cached:
+            user_id_key = cached.get('user_id_key')
+            user = await self.cache.get(user_id_key) if user_id_key else None
+            if not user or REFRESH_TOKEN_KEY not in user:
+                raise UnauthorizedException(msg='invalid_grant')
+            res = self.apply_token(user)
+            current_rt = user.get(REFRESH_TOKEN_KEY)
+            auth_res = {k: res[k] for k in ['user_id', 'token'] if k in res}
+            if current_rt:
+                auth_res[REFRESH_TOKEN_KEY] = current_rt
+            return {
+                'auth': auth_res,
+            }
+
+        # Normal path: cached 是 user_id_key 字串
+        user_id_key = cached
         user = await self.cache.get(user_id_key)
         if not user:
             await self.cache.delete(_refresh_token_index_key(refresh_token))
@@ -461,7 +496,7 @@ class AuthService:
         await self.cache_auth_res(
             user_id_key,
             user,
-            revoke_previous_refresh=refresh_token,
+            grace_previous_refresh=refresh_token,
         )
         res = self.apply_token(user)
         new_rt = user.get(REFRESH_TOKEN_KEY)


### PR DESCRIPTION
## Summary

`/v1/auth/token` revoked the prior `rt:{old}` index the instant a new pair was issued, so concurrent refresh callers racing on the same starting token saw one win and the rest hit `cache.get(rt:{old}) -> None -> 401 invalid_grant`. Combined with the FE middleware that clears the session cookie on `RefreshTokenError`, the race turned into an instant boot for the user (commonly observed ~25-30 min after login when the access token first needs refreshing and the page has multiple parallel session reads — including across different FE Lambda instances where the in-process dedupe `Map` in `auth.config.ts` cannot help).

## Change

- `cache_auth_res` now takes `grace_previous_refresh`. After the new rt is committed, the old `rt:` index is overwritten with a short-lived `{replaced_by, user_id_key}` marker (`REFRESH_TOKEN_GRACE_TTL`, default 10s) instead of being deleted.
- `get_new_token_pair` detects the marker and returns the user''s current token pair **without re-rotating**, so all racing callers converge on the same new pair.
- Login / logout continue to pass `revoke_previous_refresh` for immediate eviction — those paths are user-driven with no race.
- Order matters: the new rt is written *before* the old index is replaced, so a parallel reader never sees `replaced_by` pointing at an uncommitted token.

## Race trace (before / after)

Before:
```
R1 (rt1) -> rotate -> rt2, delete rt:rt1     -> 201, FE gets rt2
R2 (rt1) -> rt:rt1 not found                 -> 401, FE -> RefreshTokenError -> middleware logs the user out
```

After:
```
R1 (rt1) -> rotate -> rt2, mark rt:rt1 = {replaced_by: rt2}  -> 201, FE gets rt2
R2 (rt1) -> rt:rt1 = grace marker -> read user.rt = rt2, no re-rotate -> 201, FE gets rt2
(marker expires after REFRESH_TOKEN_GRACE_TTL)
```

## Cross-repo context

The FE-side coalescing added in `X-Talent-Frontend@6d17f13` (`fix(auth): dedupe in-flight refresh-token rotations`) only handles parallel jwt callbacks within the same Node process. Multi-Lambda fan-out (Vercel) bypasses that Map, which is what shows up in CloudWatch as the 30-minute 401.

## Test plan

- [ ] Deploy to dev (`npm run serverless:deploy:xchange:dev`)
- [ ] Login with `testing_visitor@xchange.com.tw`
- [ ] Fire two parallel `POST /v1/auth/token` requests with the same `refresh_token` -> both 201, both return identical new `refresh_token` in Set-Cookie
- [ ] Send the same old `refresh_token` 11+ seconds after rotation -> 401 (grace expired)
- [ ] Verify login still revokes the previous rt immediately (re-login twice, replay first rt -> 401)
- [ ] CloudWatch: no `POST /api/v1/auth/token 401` from normal refresh traffic over 24h

## Tunables

- `REFRESH_TOKEN_GRACE_TTL` env var (default 10s). Trade-off: longer window covers slower clients / cross-instance drift; shorter window narrows the replay surface for a stolen old rt. 10s is the same default Supabase uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)